### PR TITLE
Blockierende Fehler beheben

### DIFF
--- a/24x7-guide_de.md
+++ b/24x7-guide_de.md
@@ -186,6 +186,42 @@ Schlechte Tasks sind vage: "Verbessere die Codebase" oder "Fix alles". Claude rÃ
 
 ## Lektion 6: Starten und Ã¼berwachen
 
+### Dateien in den Workspace kopieren
+
+```bash
+cd /dein/workspace
+
+# Das Glob * erfasst keine Dotfiles, .claude braucht einen eigenen Schritt
+cp -r /pfad/zu/24x7-setup/* .
+
+# Hook-Konfiguration. Eine vorhandene settings.json wird nicht ueberschrieben.
+if [ -e .claude/settings.json ]; then
+  echo "STOPP: .claude/settings.json existiert, zusammenfuehren statt kopieren (siehe unten)"
+else
+  mkdir -p .claude
+  cp -R /pfad/zu/24x7-setup/.claude/. .claude/
+fi
+
+# Ohne diese Datei laeuft der Runner voellig ohne Hooks
+test -f .claude/settings.json && echo "Hooks aktiv" || echo "WARNUNG: keine Hooks"
+```
+
+**Wenn `.claude/settings.json` schon existiert:** zusammenfuehren statt kopieren.
+Der Befehl behaelt deine eigenen Eintraege und haengt die 24x7-Hooks je
+Ereignistyp an:
+
+```bash
+jq -s '(.[0].hooks // {}) as $mine | (.[1].hooks // {}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \
+  .claude/settings.json /pfad/zu/24x7-setup/.claude/settings.json \
+  > .claude/settings.merged.json
+
+# durchlesen, dann uebernehmen
+mv .claude/settings.merged.json .claude/settings.json
+```
+
 ### Runner starten
 
 ```bash

--- a/24x7-guide_de.md
+++ b/24x7-guide_de.md
@@ -23,6 +23,7 @@ Nach dieser Anleitung kannst du:
 
 - [ ] **Claude Code CLI** installiert und authentifiziert
 - [ ] **bash**, **python3** (mindestens 3.9) und **jq** im PATH
+- [ ] **timeout** oder **gtimeout** im PATH. macOS bringt `timeout` nicht mit: `brew install coreutils` liefert `gtimeout`. Ohne eins von beiden startet der Runner nicht.
 - [ ] **macOS** empfohlen (für Sandbox). Linux funktioniert ohne.
 - [ ] Ein Verzeichnis für den Workspace (kein Git nötig, anders als bei Nightshift)
 

--- a/24x7-guide_de.md
+++ b/24x7-guide_de.md
@@ -22,7 +22,7 @@ Nach dieser Anleitung kannst du:
 ## Voraussetzungen
 
 - [ ] **Claude Code CLI** installiert und authentifiziert
-- [ ] **bash**, **python3** und **jq** im PATH
+- [ ] **bash**, **python3** (mindestens 3.9) und **jq** im PATH
 - [ ] **macOS** empfohlen (für Sandbox). Linux funktioniert ohne.
 - [ ] Ein Verzeichnis für den Workspace (kein Git nötig, anders als bei Nightshift)
 

--- a/24x7-guide_en.md
+++ b/24x7-guide_en.md
@@ -23,6 +23,7 @@ After this guide, you will be able to:
 
 - [ ] **Claude Code CLI** installed and authenticated
 - [ ] **bash**, **python3** (3.9 or newer), and **jq** in your PATH
+- [ ] **timeout** or **gtimeout** in your PATH. macOS does not ship `timeout`: `brew install coreutils` provides `gtimeout`. Without either, the runner refuses to start.
 - [ ] **macOS** recommended (for sandbox). Linux works without it.
 - [ ] A directory for the workspace (no git required, unlike Nightshift)
 

--- a/24x7-guide_en.md
+++ b/24x7-guide_en.md
@@ -22,7 +22,7 @@ After this guide, you will be able to:
 ## Prerequisites
 
 - [ ] **Claude Code CLI** installed and authenticated
-- [ ] **bash**, **python3**, and **jq** in your PATH
+- [ ] **bash**, **python3** (3.9 or newer), and **jq** in your PATH
 - [ ] **macOS** recommended (for sandbox). Linux works without it.
 - [ ] A directory for the workspace (no git required, unlike Nightshift)
 

--- a/24x7-guide_en.md
+++ b/24x7-guide_en.md
@@ -207,6 +207,41 @@ Bad tasks are vague: "improve the codebase" or "fix everything". Claude will gue
 
 ## Lesson 6: Start and Monitor
 
+### Copy the Files Into the Workspace
+
+```bash
+cd /your/workspace
+
+# The * glob does not match dotfiles, so .claude needs its own step
+cp -r /path/to/24x7-setup/* .
+
+# Hook configuration. An existing settings.json is never overwritten.
+if [ -e .claude/settings.json ]; then
+  echo "STOP: .claude/settings.json exists, merge it instead of copying (see below)"
+else
+  mkdir -p .claude
+  cp -R /path/to/24x7-setup/.claude/. .claude/
+fi
+
+# Without this file the runner has no hooks at all
+test -f .claude/settings.json && echo "hooks in place" || echo "WARNING: no hooks"
+```
+
+**If `.claude/settings.json` already exists**, merge instead of copying. The
+command keeps your own entries and appends the 24x7 hooks per event type:
+
+```bash
+jq -s '(.[0].hooks // {}) as $mine | (.[1].hooks // {}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \
+  .claude/settings.json /path/to/24x7-setup/.claude/settings.json \
+  > .claude/settings.merged.json
+
+# read it, then take it over
+mv .claude/settings.merged.json .claude/settings.json
+```
+
 ### Start the Runner
 
 ```bash

--- a/24x7/SKILL.md
+++ b/24x7/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: 24x7
 license: Apache-2.0
-compatibility: "Requires Claude Code CLI (claude -p), bash, python3, jq. macOS recommended for sandbox-exec. timeout command required."
+compatibility: "Requires Claude Code CLI (claude -p), bash, python3 >= 3.9, jq. macOS recommended for sandbox-exec. timeout or gtimeout required."
 description: "Generates an endless Claude Code runner with inbox/outbox folder architecture as ZIP. Claude processes tasks from an inbox folder, delivers results to an outbox folder, and runs idle tasks when the queue is empty. Use this skill whenever someone wants a permanent Claude agent, a task queue, a job runner, or a drop-folder workflow. Trigger phrases: endloser Runner, 24/7 Claude, Daemon, Always-On, Job-Queue, Inbox Outbox, Drop-Folder, Hot-Folder, Task-Warteschlange, Claude als Service, dauerhaft laufen lassen."
 ---
 

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -522,34 +522,35 @@ Autonomy zones and error tolerance inspired by [AlpiType — Solving the AI Agen
 #  ZIP BAUEN
 # ════════════════════════════════════════════════════════════
 
-ZIP_PATH = "/mnt/user-data/outputs/24x7-setup.zip"
+if __name__ == "__main__":
+    ZIP_PATH = "/mnt/user-data/outputs/24x7-setup.zip"
 
-idle_content = IDLE_TASKS.get(IDLE_BEHAVIOR, IDLE_TASKS["sleep"])
+    idle_content = IDLE_TASKS.get(IDLE_BEHAVIOR, IDLE_TASKS["sleep"])
 
-files = {
-    "CLAUDE.md": CLAUDE_MD,
-    ".claude/settings.json": json.dumps(SETTINGS, indent=2, ensure_ascii=False),
-    "runner.sh": RUNNER_SH,
-    "runner-bg.sh": RUNNER_BG_SH,
-    "watchdog.sh": WATCHDOG_SH,
-    "sandbox.sb": SANDBOX_SB,
-    "idle/idle-tasks.md": idle_content,
-    "inbox/.gitkeep": "",
-    "working/.gitkeep": "",
-    "outbox/.gitkeep": "",
-    "failed/.gitkeep": "",
-    "inbox/beispiel-task/task.md": EXAMPLE_TASK,
-    "inbox/beispiel-task/materials/.gitkeep": "",
-    "README.md": README,
-}
+    files = {
+        "CLAUDE.md": CLAUDE_MD,
+        ".claude/settings.json": json.dumps(SETTINGS, indent=2, ensure_ascii=False),
+        "runner.sh": RUNNER_SH,
+        "runner-bg.sh": RUNNER_BG_SH,
+        "watchdog.sh": WATCHDOG_SH,
+        "sandbox.sb": SANDBOX_SB,
+        "idle/idle-tasks.md": idle_content,
+        "inbox/.gitkeep": "",
+        "working/.gitkeep": "",
+        "outbox/.gitkeep": "",
+        "failed/.gitkeep": "",
+        "inbox/beispiel-task/task.md": EXAMPLE_TASK,
+        "inbox/beispiel-task/materials/.gitkeep": "",
+        "README.md": README,
+    }
 
-with zipfile.ZipFile(ZIP_PATH, "w", zipfile.ZIP_DEFLATED) as zf:
-    for filename, content in files.items():
-        zf.writestr(f"24x7-setup/{filename}", content)
+    with zipfile.ZipFile(ZIP_PATH, "w", zipfile.ZIP_DEFLATED) as zf:
+        for filename, content in files.items():
+            zf.writestr(f"24x7-setup/{filename}", content)
 
-print(f"✅ 24x7-setup.zip erstellt: {ZIP_PATH}")
-print(f"   Workspace:      {WORKSPACE}")
-print(f"   Poll-Intervall:  {POLL_INTERVAL}s")
-print(f"   Task-Timeout:    {MAX_TASK_MINUTES} Min")
-print(f"   Idle-Verhalten:  {IDLE_BEHAVIOR}")
-print(f"   Dateien:         {len(files)}")
+    print(f"✅ 24x7-setup.zip erstellt: {ZIP_PATH}")
+    print(f"   Workspace:      {WORKSPACE}")
+    print(f"   Poll-Intervall:  {POLL_INTERVAL}s")
+    print(f"   Task-Timeout:    {MAX_TASK_MINUTES} Min")
+    print(f"   Idle-Verhalten:  {IDLE_BEHAVIOR}")
+    print(f"   Dateien:         {len(files)}")

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -118,13 +118,16 @@ Nichts. Session sofort beenden.
 # ── PreToolUse-Hook: rote Zone ──────────────────────────────
 # Das Muster wird im Hook einfach gequotet, damit Backslashes
 # unveraendert bei grep ankommen. Die rm-Regel trifft gefaehrliche
-# Ziele (Wurzel, Home, Globs, Elternpfade, Systemordner, .git),
-# nicht jedes rm -rf: "rm -rf node_modules" bleibt erlaubt.
+# Ziele: Wurzel, Home und dessen direkte Kinder, Globs, Elternpfade,
+# Systemordner, .git. Nicht getroffen wird das taegliche Aufraeumen,
+# auch nicht mit absolutem Pfad: "rm -rf node_modules",
+# "rm -rf /Users/ich/projekt/dist", "rm -f *.log" laufen durch.
 BLOCK_PATTERN = (
     "rm +(-[A-Za-z-]+ +)*("
-    "/( |$)|/\\*|~|\\$HOME|\\*|\\.\\.|\\./\\*|\\.( |$)|\\.git( |/|$)"
-    "|/(bin|boot|dev|etc|home|lib|opt|private|root|sbin|sys|usr|var"
-    "|Applications|Library|System|Users|Volumes)( |/|$)"
+    "/( |$)|/\\*/?( |$)|\\*/?( |$)|\\./\\*/?( |$)|\\.\\.|\\./?( |$)|\\.git/?( |$)"
+    "|(~|\\$HOME|/home|/Users|/Volumes|/private)(/[^/ ]+)?/?( |$)"
+    "|/(bin|boot|dev|etc|lib|opt|root|sbin|sys|usr|var"
+    "|Applications|Library|System)( |/|$)"
     ")"
     "|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\|.*bash|eval |> /dev/sd"
 )

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -116,6 +116,19 @@ Nichts. Session sofort beenden.
 }
 
 # ── PreToolUse-Hook: rote Zone ──────────────────────────────
+# Das Muster wird im Hook einfach gequotet, damit Backslashes
+# unveraendert bei grep ankommen. Die rm-Regel trifft gefaehrliche
+# Ziele (Wurzel, Home, Globs, Elternpfade, Systemordner, .git),
+# nicht jedes rm -rf: "rm -rf node_modules" bleibt erlaubt.
+BLOCK_PATTERN = (
+    "rm +(-[A-Za-z-]+ +)*("
+    "/( |$)|/\\*|~|\\$HOME|\\*|\\.\\.|\\./\\*|\\.( |$)|\\.git( |/|$)"
+    "|/(bin|boot|dev|etc|home|lib|opt|private|root|sbin|sys|usr|var"
+    "|Applications|Library|System|Users|Volumes)( |/|$)"
+    ")"
+    "|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\|.*bash|eval |> /dev/sd"
+)
+
 # Ohne jq kann der Hook nichts pruefen. Dann blockt er und sagt warum,
 # statt still durchzuwinken (fail closed).
 BLOCK_CMD = (
@@ -126,12 +139,13 @@ BLOCK_CMD = (
     "INPUT=$(cat); "
     'CMD=$(printf "%s" "$INPUT" | jq -r ".tool_input.command // empty") || '
     '{ echo "24x7 BLOCKED: jq konnte die Eingabe nicht lesen" >&2; exit 2; }; '
-    'if [ -n "$CMD" ] && printf "%s" "$CMD" | '
-    "grep -qE \"rm -rf /|rm -rf ~|rm -rf \\\\\\\\*|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\\\|.*bash|eval |> /dev/sd\"; then "
+    'if [ -n "$CMD" ] && printf "%s" "$CMD" | grep -qE '
+    "'\\''" + BLOCK_PATTERN + "'\\''; then "
     'echo "24x7 BLOCKED: Destruktiver Befehl" >&2; exit 2; '
     "fi; "
     "exit 0'"
 )
+
 
 SETTINGS = {
     "hooks": {

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -188,6 +188,21 @@ MAX_SECONDS={MAX_TASK_MINUTES * 60}
 IDLE_SECONDS={IDLE_TIMEOUT_MINUTES * 60}
 LOGFILE="/tmp/24x7-$(date +%Y%m%d).log"
 
+# Timeout-Kommando bestimmen. Ohne Timeout laeuft ein haengender Task
+# unbegrenzt weiter, deshalb Abbruch statt stillem Weiterlaufen.
+# macOS bringt kein timeout mit; coreutils installiert es als gtimeout.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "❌ Weder 'timeout' noch 'gtimeout' gefunden."
+    echo "   Der Runner braucht eins von beiden, um Tasks zu deckeln."
+    echo "   macOS: brew install coreutils (liefert gtimeout)"
+    echo "   Linux: Paket coreutils installieren"
+    exit 1
+fi
+
 # PID-Lock: Verhindert doppelten Start
 PIDFILE="/tmp/24x7.pid"
 if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
@@ -221,7 +236,7 @@ echo "============================================" | tee -a "$LOGFILE"
 echo "  Claude 24x7 Runner gestartet: $(date)" | tee -a "$LOGFILE"
 echo "  Workspace: $WORKSPACE" | tee -a "$LOGFILE"
 echo "  Poll-Intervall: ${{POLL}}s" | tee -a "$LOGFILE"
-echo "  Task-Timeout: {MAX_TASK_MINUTES} Min" | tee -a "$LOGFILE"
+echo "  Task-Timeout: {MAX_TASK_MINUTES} Min (via $TIMEOUT_BIN)" | tee -a "$LOGFILE"
 echo "  Idle: {IDLE_BEHAVIOR}" | tee -a "$LOGFILE"
 echo "  Log: $LOGFILE" | tee -a "$LOGFILE"
 echo "  PID: $$" | tee -a "$LOGFILE"
@@ -265,7 +280,7 @@ while true; do
 
     # Claude starten mit Timeout
     echo "   ▶ Claude startet..." | tee -a "$LOGFILE"
-    timeout $MAX_SECONDS claude -p \\
+    "$TIMEOUT_BIN" $MAX_SECONDS claude -p \\
       "Du bearbeitest folgenden Task im Ordner $WORKING/$TASK_NAME.
 
 AUFTRAG (aus task.md):
@@ -312,7 +327,7 @@ REGELN:
     cp "$IDLE/idle-tasks.md" "$IDLE_DIR/task.md" 2>/dev/null
 
     if [ -f "$IDLE_DIR/task.md" ] && ! grep -q "Session sofort beenden" "$IDLE_DIR/task.md"; then
-      timeout $IDLE_SECONDS claude -p \\
+      "$TIMEOUT_BIN" $IDLE_SECONDS claude -p \\
         "Du bist im Idle-Modus. Lies $IDLE_DIR/task.md und arbeite die Idle-Aufgaben ab.
 Ergebnisse in $IDLE_DIR/output/ ablegen.
 Workspace-Root ist $WORKSPACE.

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -117,11 +117,14 @@ Nichts. Session sofort beenden.
 
 # ── PreToolUse-Hook: rote Zone ──────────────────────────────
 # Das Muster wird im Hook einfach gequotet, damit Backslashes
-# unveraendert bei grep ankommen. Die rm-Regel trifft gefaehrliche
-# Ziele: Wurzel, Home und dessen direkte Kinder, Globs, Elternpfade,
-# Systemordner, .git. Nicht getroffen wird das taegliche Aufraeumen,
-# auch nicht mit absolutem Pfad: "rm -rf node_modules",
-# "rm -rf /Users/ich/projekt/dist", "rm -f *.log" laufen durch.
+# unveraendert bei grep ankommen. Anfuehrungszeichen schneidet der
+# Hook vor dem grep mit tr aus dem Kommando, deshalb muss das Muster
+# sie nicht kennen und rm -rf "/" blockt genauso wie rm -rf /.
+# Die rm-Regel trifft gefaehrliche Ziele: Wurzel, Home und dessen
+# direkte Kinder, Globs, Elternpfade, Systemordner, .git. Nicht
+# getroffen wird das taegliche Aufraeumen, auch nicht mit absolutem
+# Pfad: "rm -rf node_modules", "rm -rf /Users/ich/projekt/dist",
+# "rm -f *.log" laufen durch.
 BLOCK_PATTERN = (
     "rm +(-[A-Za-z-]+ +)*("
     "/( |$)|/\\*/?( |$)|\\*/?( |$)|\\./\\*/?( |$)|\\.\\.|\\./?( |$)|\\.git/?( |$)"
@@ -142,7 +145,7 @@ BLOCK_CMD = (
     "INPUT=$(cat); "
     'CMD=$(printf "%s" "$INPUT" | jq -r ".tool_input.command // empty") || '
     '{ echo "24x7 BLOCKED: jq konnte die Eingabe nicht lesen" >&2; exit 2; }; '
-    'if [ -n "$CMD" ] && printf "%s" "$CMD" | grep -qE '
+    'if [ -n "$CMD" ] && printf "%s" "$CMD" | tr -d "\\047\\042" | grep -qE '
     "'\\''" + BLOCK_PATTERN + "'\\''; then "
     'echo "24x7 BLOCKED: Destruktiver Befehl" >&2; exit 2; '
     "fi; "

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -115,6 +115,24 @@ Nichts. Session sofort beenden.
 """
 }
 
+# ── PreToolUse-Hook: rote Zone ──────────────────────────────
+# Ohne jq kann der Hook nichts pruefen. Dann blockt er und sagt warum,
+# statt still durchzuwinken (fail closed).
+BLOCK_CMD = (
+    "bash -c '"
+    "if ! command -v jq >/dev/null 2>&1; then "
+    'echo "24x7 BLOCKED: jq nicht gefunden, Kommando nicht pruefbar" >&2; exit 2; '
+    "fi; "
+    "INPUT=$(cat); "
+    'CMD=$(printf "%s" "$INPUT" | jq -r ".tool_input.command // empty") || '
+    '{ echo "24x7 BLOCKED: jq konnte die Eingabe nicht lesen" >&2; exit 2; }; '
+    'if [ -n "$CMD" ] && printf "%s" "$CMD" | '
+    "grep -qE \"rm -rf /|rm -rf ~|rm -rf \\\\\\\\*|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\\\|.*bash|eval |> /dev/sd\"; then "
+    'echo "24x7 BLOCKED: Destruktiver Befehl" >&2; exit 2; '
+    "fi; "
+    "exit 0'"
+)
+
 SETTINGS = {
     "hooks": {
         "PreToolUse": [
@@ -123,14 +141,7 @@ SETTINGS = {
                 "hooks": [
                     {
                         "type": "command",
-                        "command": (
-                            "bash -c '"
-                            'CMD=$(cat | jq -r ".tool_input.command // empty"); '
-                            'if [ -n "$CMD" ] && echo "$CMD" | '
-                            "grep -qE \"rm -rf /|rm -rf ~|rm -rf \\\\\\\\*|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\\\|.*bash|eval |> /dev/sd\"; "
-                            'then echo "24x7 BLOCKED: Destruktiver Befehl" >&2; exit 2; fi; '
-                            "exit 0'"
-                        ),
+                        "command": BLOCK_CMD,
                     }
                 ],
             }

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -470,8 +470,17 @@ README = f"""# Claude 24x7 — Endless Runner
 ```bash
 # 1. Unzip and install
 unzip 24x7-setup.zip
-cp -r 24x7-setup/* {WORKSPACE}/
-chmod +x {WORKSPACE}/runner.sh {WORKSPACE}/runner-bg.sh {WORKSPACE}/watchdog.sh
+cd {WORKSPACE}
+# The * glob does not match dotfiles, .claude needs its own step
+cp -r /path/to/24x7-setup/* .
+if [ -e .claude/settings.json ]; then
+  echo "STOP: .claude/settings.json exists, merge it (see below)"
+else
+  mkdir -p .claude
+  cp -R /path/to/24x7-setup/.claude/. .claude/
+fi
+test -f .claude/settings.json && echo "hooks in place" || echo "WARNING: no hooks"
+chmod +x runner.sh runner-bg.sh watchdog.sh
 
 # 2. Start
 cd {WORKSPACE}
@@ -479,6 +488,23 @@ cd {WORKSPACE}
 
 # 3. Watchdog (second terminal)
 ./watchdog.sh
+```
+
+## Existing .claude/settings.json
+
+Copying would drop your own hooks, permissions, and MCP settings. Merge instead.
+The command keeps your entries and appends the 24x7 hooks per event type:
+
+```bash
+jq -s '(.[0].hooks // {{}}) as $mine | (.[1].hooks // {{}}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({{}}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \\
+  .claude/settings.json /path/to/24x7-setup/.claude/settings.json \\
+  > .claude/settings.merged.json
+
+# read it, then take it over
+mv .claude/settings.merged.json .claude/settings.json
 ```
 
 ## Drop a Task

--- a/README.md
+++ b/README.md
@@ -205,12 +205,37 @@ Claude will:
 
 ```bash
 cd /your/project
-cp -r nightshift-setup/.claude .
 cp nightshift-setup/runbook.md .
 cp nightshift-setup/nightshift-*.sh .
 cp nightshift-setup/nightshift-sandbox.sb .
 cat nightshift-setup/CLAUDE-nightshift.md >> CLAUDE.md
 chmod +x nightshift-*.sh
+
+# Hook configuration. An existing settings.json is never overwritten.
+if [ -e .claude/settings.json ]; then
+  echo "STOP: .claude/settings.json exists, merge it instead of copying (see below)"
+else
+  mkdir -p .claude
+  cp -R nightshift-setup/.claude/. .claude/
+fi
+
+# Without this file the run has no hooks and no protection layer
+test -f .claude/settings.json && echo "hooks in place" || echo "WARNING: no hooks"
+```
+
+**If `.claude/settings.json` already exists**, merging keeps your own hooks,
+permissions, and MCP settings and appends the Nightshift hooks per event type:
+
+```bash
+jq -s '(.[0].hooks // {}) as $mine | (.[1].hooks // {}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \
+  .claude/settings.json nightshift-setup/.claude/settings.json \
+  > .claude/settings.merged.json
+
+# read it, then take it over
+mv .claude/settings.merged.json .claude/settings.json
 ```
 
 ### Step 3: Commit Your Current State
@@ -278,10 +303,39 @@ Claude will generate the workspace structure with runner, watchdog, hooks, and s
 ### Step 2: Install and Start
 
 ```bash
-cp -r 24x7-setup/* /your/workspace/
-chmod +x /your/workspace/*.sh
 cd /your/workspace
+
+# The * glob does not match dotfiles, so .claude needs its own step
+cp -r /path/to/24x7-setup/* .
+
+# Hook configuration. An existing settings.json is never overwritten.
+if [ -e .claude/settings.json ]; then
+  echo "STOP: .claude/settings.json exists, merge it instead of copying (see below)"
+else
+  mkdir -p .claude
+  cp -R /path/to/24x7-setup/.claude/. .claude/
+fi
+
+# Without this file the daemon runs with no hooks at all
+test -f .claude/settings.json && echo "hooks in place" || echo "WARNING: no hooks"
+
+chmod +x *.sh
 ./runner-bg.sh
+```
+
+**If `.claude/settings.json` already exists**, merging keeps your own entries
+and appends the 24x7 hooks per event type:
+
+```bash
+jq -s '(.[0].hooks // {}) as $mine | (.[1].hooks // {}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \
+  .claude/settings.json /path/to/24x7-setup/.claude/settings.json \
+  > .claude/settings.merged.json
+
+# read it, then take it over
+mv .claude/settings.merged.json .claude/settings.json
 ```
 
 ### Step 3: Drop Tasks

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The 24x7 skill uses the same pattern at workspace level: each task reads `decisi
 ### Prerequisites
 
 - **Claude Code CLI** installed and authenticated (`claude` command available)
-- **bash**, **python3**, **jq** in your PATH
+- **bash**, **python3 3.9 or newer**, **jq** in your PATH (the build scripts are tested against the macOS system Python 3.9)
 - **macOS** recommended (for `sandbox-exec`). Works on Linux without the sandbox layer.
 - A **git repository** for your project (Nightshift) or any directory (24x7)
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The 24x7 skill uses the same pattern at workspace level: each task reads `decisi
 
 - **Claude Code CLI** installed and authenticated (`claude` command available)
 - **bash**, **python3 3.9 or newer**, **jq** in your PATH (the build scripts are tested against the macOS system Python 3.9)
+- **timeout** or **gtimeout** for 24x7 only. macOS does not ship `timeout`; `brew install coreutils` provides `gtimeout`. The runner uses whichever it finds and refuses to start without one.
 - **macOS** recommended (for `sandbox-exec`). Works on Linux without the sandbox layer.
 - A **git repository** for your project (Nightshift) or any directory (24x7)
 

--- a/index.html
+++ b/index.html
@@ -1284,7 +1284,13 @@
 <span class="comment">#  — migrate auth module to JWT"</span>
 
 <span class="comment"># Copy generated files into project</span>
+<span class="comment"># (the * glob skips dotfiles, .claude needs its own step)</span>
 <span class="cmd">cp</span> <span class="flag">-r</span> nightshift-setup/* <span class="path">/my/project/</span>
+<span class="comment"># Hooks live in .claude, copy only if there is none yet,</span>
+<span class="comment"># otherwise merge (see the guide), never overwrite</span>
+<span class="cmd">test</span> <span class="flag">-e</span> <span class="path">/my/project/.claude/settings.json</span> \
+  && <span class="cmd">echo</span> "settings.json exists, merge it" \
+  || <span class="cmd">cp</span> <span class="flag">-R</span> nightshift-setup/.claude <span class="path">/my/project/</span>
 <span class="cmd">chmod</span> <span class="flag">+x</span> <span class="path">/my/project/</span>nightshift-*.sh
 <span class="cmd">cd</span> <span class="path">/my/project</span>
 
@@ -1315,7 +1321,13 @@
 <span class="comment"># "Set up a 24x7 runner at /claude-workspace"</span>
 
 <span class="comment"># Copy and start</span>
+<span class="comment"># (the * glob skips dotfiles, .claude needs its own step)</span>
 <span class="cmd">cp</span> <span class="flag">-r</span> 24x7-setup/* <span class="path">/claude-workspace/</span>
+<span class="comment"># Hooks live in .claude, copy only if there is none yet,</span>
+<span class="comment"># otherwise merge (see the guide), never overwrite</span>
+<span class="cmd">test</span> <span class="flag">-e</span> <span class="path">/claude-workspace/.claude/settings.json</span> \
+  && <span class="cmd">echo</span> "settings.json exists, merge it" \
+  || <span class="cmd">cp</span> <span class="flag">-R</span> 24x7-setup/.claude <span class="path">/claude-workspace/</span>
 <span class="cmd">chmod</span> <span class="flag">+x</span> <span class="path">/claude-workspace/</span>*.sh
 <span class="cmd">cd</span> <span class="path">/claude-workspace</span>
 <span class="cmd">./runner-bg.sh</span>

--- a/index.html
+++ b/index.html
@@ -1244,8 +1244,8 @@
       </div>
       <div class="problem-card" style="border-top: 2px solid var(--accent-green);">
         <div class="problem-icon">🐚</div>
-        <h3>bash, python3, jq</h3>
-        <p>The runner scripts are bash. The build script is Python. Hooks use jq to parse JSON. All three must be in your PATH.</p>
+        <h3>bash, python3 (3.9+), jq</h3>
+        <p>The runner scripts are bash. The build script is Python and needs version 3.9 or newer. Hooks use jq to parse JSON. All three must be in your PATH.</p>
       </div>
       <div class="problem-card" style="border-top: 2px solid var(--accent-green);">
         <div class="problem-icon">🍎</div>

--- a/index.html
+++ b/index.html
@@ -1245,7 +1245,7 @@
       <div class="problem-card" style="border-top: 2px solid var(--accent-green);">
         <div class="problem-icon">🐚</div>
         <h3>bash, python3 (3.9+), jq</h3>
-        <p>The runner scripts are bash. The build script is Python and needs version 3.9 or newer. Hooks use jq to parse JSON. All three must be in your PATH.</p>
+        <p>The runner scripts are bash. The build script is Python and needs version 3.9 or newer. Hooks use jq to parse JSON. All three must be in your PATH. The 24x7 runner additionally needs <code>timeout</code> or <code>gtimeout</code> — macOS ships neither, <code>brew install coreutils</code> provides <code>gtimeout</code>.</p>
       </div>
       <div class="problem-card" style="border-top: 2px solid var(--accent-green);">
         <div class="problem-icon">🍎</div>

--- a/nightshift-guide_de.md
+++ b/nightshift-guide_de.md
@@ -133,12 +133,38 @@ Claude erzeugt diese Dateien:
 
 ```bash
 cd /dein/projekt
-cp -r nightshift-setup/.claude .
 cp nightshift-setup/runbook.md .
 cp nightshift-setup/nightshift-*.sh .
 cp nightshift-setup/nightshift-sandbox.sb .
 cat nightshift-setup/CLAUDE-nightshift.md >> CLAUDE.md
 chmod +x nightshift-*.sh
+
+# Hook-Konfiguration. Eine vorhandene settings.json wird nicht ueberschrieben.
+if [ -e .claude/settings.json ]; then
+  echo "STOPP: .claude/settings.json existiert, zusammenfuehren statt kopieren (siehe unten)"
+else
+  mkdir -p .claude
+  cp -R nightshift-setup/.claude/. .claude/
+fi
+
+# Ohne diese Datei laeuft der Lauf ohne Hooks und ohne Schutzschicht
+test -f .claude/settings.json && echo "Hooks aktiv" || echo "WARNUNG: keine Hooks"
+```
+
+**Wenn `.claude/settings.json` schon existiert:** zusammenfuehren statt kopieren.
+Der Befehl behaelt deine eigenen Hooks, Permissions und MCP-Einstellungen und
+haengt die Nightshift-Hooks je Ereignistyp an:
+
+```bash
+jq -s '(.[0].hooks // {}) as $mine | (.[1].hooks // {}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \
+  .claude/settings.json nightshift-setup/.claude/settings.json \
+  > .claude/settings.merged.json
+
+# durchlesen, dann uebernehmen
+mv .claude/settings.merged.json .claude/settings.json
 ```
 
 ### 4.2 Vorher committen (Pflicht!)

--- a/nightshift-guide_de.md
+++ b/nightshift-guide_de.md
@@ -24,7 +24,7 @@ Nach dieser Anleitung kannst du:
 Stelle sicher, dass du folgendes hast:
 
 - [ ] **Claude Code CLI** installiert und authentifiziert (tippe `claude` im Terminal)
-- [ ] **bash**, **python3** und **jq** im PATH
+- [ ] **bash**, **python3** (mindestens 3.9) und **jq** im PATH
 - [ ] **Ein Git-Repository** mit deinem Projekt (für Rollback)
 - [ ] **macOS** empfohlen (für Kernel-Level-Sandbox). Linux funktioniert ohne Sandbox — nutze stattdessen Docker.
 

--- a/nightshift-guide_en.md
+++ b/nightshift-guide_en.md
@@ -24,7 +24,7 @@ After this guide, you will be able to:
 Before you start, make sure you have:
 
 - [ ] **Claude Code CLI** installed and authenticated (type `claude` in your terminal — if it opens, you're good)
-- [ ] **bash**, **python3**, and **jq** in your PATH
+- [ ] **bash**, **python3** (3.9 or newer), and **jq** in your PATH
 - [ ] **A git repository** with your project (you need git for rollback)
 - [ ] **macOS** recommended (for kernel-level sandbox). Linux works without the sandbox — use Docker instead.
 

--- a/nightshift-guide_en.md
+++ b/nightshift-guide_en.md
@@ -136,12 +136,38 @@ Claude generates these files:
 
 ```bash
 cd /your/project
-cp -r nightshift-setup/.claude .
 cp nightshift-setup/runbook.md .
 cp nightshift-setup/nightshift-*.sh .
 cp nightshift-setup/nightshift-sandbox.sb .
 cat nightshift-setup/CLAUDE-nightshift.md >> CLAUDE.md
 chmod +x nightshift-*.sh
+
+# Hook configuration. An existing settings.json is never overwritten.
+if [ -e .claude/settings.json ]; then
+  echo "STOP: .claude/settings.json exists, merge it instead of copying (see below)"
+else
+  mkdir -p .claude
+  cp -R nightshift-setup/.claude/. .claude/
+fi
+
+# Without this file the run has no hooks and no protection layer
+test -f .claude/settings.json && echo "hooks in place" || echo "WARNING: no hooks"
+```
+
+**If `.claude/settings.json` already exists**, merge instead of copying. The
+command keeps your own hooks, permissions, and MCP settings and appends the
+Nightshift hooks per event type:
+
+```bash
+jq -s '(.[0].hooks // {}) as $mine | (.[1].hooks // {}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \
+  .claude/settings.json nightshift-setup/.claude/settings.json \
+  > .claude/settings.merged.json
+
+# read it, then take it over
+mv .claude/settings.merged.json .claude/settings.json
 ```
 
 ### 4.2 Commit First (Critical!)

--- a/nightshift/SKILL.md
+++ b/nightshift/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nightshift
 license: Apache-2.0
-compatibility: "Requires Claude Code CLI (claude -p), bash, python3, jq. macOS recommended for sandbox-exec."
+compatibility: "Requires Claude Code CLI (claude -p), bash, python3 >= 3.9, jq. macOS recommended for sandbox-exec."
 description: "Generates a complete autonomous Claude Code setup as ZIP from a project path and task description. Includes a validated runbook with genre templates, security hooks, heartbeat watchdog, and macOS sandbox profile. Use this skill whenever someone wants to run Claude Code autonomously, overnight, or unattended. Also use for headless Claude Code, dangerously-skip-permissions setup, autonomous agent runs, or batch project work. Trigger phrases: Nachtlauf, Nightshift, autonom arbeiten, über Nacht, YOLO mode einrichten, Claude absichern, Runbook erstellen."
 ---
 

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -246,6 +246,24 @@ GENRE_TEMPLATES = {
 #  AB HIER NICHTS ÄNDERN — Dateien generieren
 # ════════════════════════════════════════════════════════════
 
+# ── PreToolUse-Hook: rote Zone ──────────────────────────────
+# Ohne jq kann der Hook nichts pruefen. Dann blockt er und sagt warum,
+# statt still durchzuwinken (fail closed).
+BLOCK_CMD = (
+    "bash -c '"
+    "if ! command -v jq >/dev/null 2>&1; then "
+    'echo "NIGHTSHIFT BLOCKED: jq nicht gefunden, Kommando nicht pruefbar" >&2; exit 2; '
+    "fi; "
+    "INPUT=$(cat); "
+    'CMD=$(printf "%s" "$INPUT" | jq -r ".tool_input.command // empty") || '
+    '{ echo "NIGHTSHIFT BLOCKED: jq konnte die Eingabe nicht lesen" >&2; exit 2; }; '
+    'if [ -n "$CMD" ] && printf "%s" "$CMD" | '
+    "grep -qE \"rm -rf /|rm -rf ~|rm -rf \\\\\\\\*|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\\\|.*bash|eval |> /dev/sd\"; then "
+    'echo "NIGHTSHIFT BLOCKED: Destruktiver Befehl" >&2; exit 2; '
+    "fi; "
+    "exit 0'"
+)
+
 SETTINGS = {
     "hooks": {
         "PreToolUse": [
@@ -254,14 +272,7 @@ SETTINGS = {
                 "hooks": [
                     {
                         "type": "command",
-                        "command": (
-                            "bash -c '"
-                            'CMD=$(cat | jq -r ".tool_input.command // empty"); '
-                            'if [ -n "$CMD" ] && echo "$CMD" | '
-                            "grep -qE \"rm -rf /|rm -rf ~|rm -rf \\\\\\\\*|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\\\|.*bash|eval |> /dev/sd\"; "
-                            'then echo "NIGHTSHIFT BLOCKED: Destruktiver Befehl" >&2; exit 2; fi; '
-                            "exit 0'"
-                        ),
+                        "command": BLOCK_CMD,
                     }
                 ],
             }

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -248,11 +248,14 @@ GENRE_TEMPLATES = {
 
 # ── PreToolUse-Hook: rote Zone ──────────────────────────────
 # Das Muster wird im Hook einfach gequotet, damit Backslashes
-# unveraendert bei grep ankommen. Die rm-Regel trifft gefaehrliche
-# Ziele: Wurzel, Home und dessen direkte Kinder, Globs, Elternpfade,
-# Systemordner, .git. Nicht getroffen wird das taegliche Aufraeumen,
-# auch nicht mit absolutem Pfad: "rm -rf node_modules",
-# "rm -rf /Users/ich/projekt/dist", "rm -f *.log" laufen durch.
+# unveraendert bei grep ankommen. Anfuehrungszeichen schneidet der
+# Hook vor dem grep mit tr aus dem Kommando, deshalb muss das Muster
+# sie nicht kennen und rm -rf "/" blockt genauso wie rm -rf /.
+# Die rm-Regel trifft gefaehrliche Ziele: Wurzel, Home und dessen
+# direkte Kinder, Globs, Elternpfade, Systemordner, .git. Nicht
+# getroffen wird das taegliche Aufraeumen, auch nicht mit absolutem
+# Pfad: "rm -rf node_modules", "rm -rf /Users/ich/projekt/dist",
+# "rm -f *.log" laufen durch.
 BLOCK_PATTERN = (
     "rm +(-[A-Za-z-]+ +)*("
     "/( |$)|/\\*/?( |$)|\\*/?( |$)|\\./\\*/?( |$)|\\.\\.|\\./?( |$)|\\.git/?( |$)"
@@ -273,7 +276,7 @@ BLOCK_CMD = (
     "INPUT=$(cat); "
     'CMD=$(printf "%s" "$INPUT" | jq -r ".tool_input.command // empty") || '
     '{ echo "NIGHTSHIFT BLOCKED: jq konnte die Eingabe nicht lesen" >&2; exit 2; }; '
-    'if [ -n "$CMD" ] && printf "%s" "$CMD" | grep -qE '
+    'if [ -n "$CMD" ] && printf "%s" "$CMD" | tr -d "\\047\\042" | grep -qE '
     "'\\''" + BLOCK_PATTERN + "'\\''; then "
     'echo "NIGHTSHIFT BLOCKED: Destruktiver Befehl" >&2; exit 2; '
     "fi; "

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -583,4 +583,7 @@ if __name__ == "__main__":
     print(f"   Aufgabe:  {AUFGABE_TITEL}")
     print(f"   Projekt:  {PROJEKTPFAD}")
     print(f"   Dateien:  {len(files)}")
-    print(f"   Schritte: {len(re.findall(r'^- \[ \]', RUNBOOK, re.MULTILINE))}")
+    # Backslashes duerfen bis Python 3.11 nicht im f-String-Ausdruck stehen,
+    # deshalb steht das Muster in einer eigenen Variablen.
+    offene_schritte = len(re.findall(r"^- \[ \]", RUNBOOK, re.MULTILINE))
+    print(f"   Schritte: {offene_schritte}")

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -249,13 +249,16 @@ GENRE_TEMPLATES = {
 # ── PreToolUse-Hook: rote Zone ──────────────────────────────
 # Das Muster wird im Hook einfach gequotet, damit Backslashes
 # unveraendert bei grep ankommen. Die rm-Regel trifft gefaehrliche
-# Ziele (Wurzel, Home, Globs, Elternpfade, Systemordner, .git),
-# nicht jedes rm -rf: "rm -rf node_modules" bleibt erlaubt.
+# Ziele: Wurzel, Home und dessen direkte Kinder, Globs, Elternpfade,
+# Systemordner, .git. Nicht getroffen wird das taegliche Aufraeumen,
+# auch nicht mit absolutem Pfad: "rm -rf node_modules",
+# "rm -rf /Users/ich/projekt/dist", "rm -f *.log" laufen durch.
 BLOCK_PATTERN = (
     "rm +(-[A-Za-z-]+ +)*("
-    "/( |$)|/\\*|~|\\$HOME|\\*|\\.\\.|\\./\\*|\\.( |$)|\\.git( |/|$)"
-    "|/(bin|boot|dev|etc|home|lib|opt|private|root|sbin|sys|usr|var"
-    "|Applications|Library|System|Users|Volumes)( |/|$)"
+    "/( |$)|/\\*/?( |$)|\\*/?( |$)|\\./\\*/?( |$)|\\.\\.|\\./?( |$)|\\.git/?( |$)"
+    "|(~|\\$HOME|/home|/Users|/Volumes|/private)(/[^/ ]+)?/?( |$)"
+    "|/(bin|boot|dev|etc|lib|opt|root|sbin|sys|usr|var"
+    "|Applications|Library|System)( |/|$)"
     ")"
     "|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\|.*bash|eval |> /dev/sd"
 )

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -536,11 +536,19 @@ unzip nightshift-setup.zip
 
 # 2. Copy into project
 cd {PROJEKTPFAD}
-cp -r /path/to/nightshift-setup/.claude .
 cp /path/to/nightshift-setup/runbook.md .
 cp /path/to/nightshift-setup/nightshift-*.sh .
 cp /path/to/nightshift-setup/nightshift-sandbox.sb .
 chmod +x nightshift-*.sh
+
+# 2a. Hook configuration, an existing settings.json is never overwritten
+if [ -e .claude/settings.json ]; then
+  echo "STOP: .claude/settings.json exists, merge it (see below)"
+else
+  mkdir -p .claude
+  cp -R /path/to/nightshift-setup/.claude/. .claude/
+fi
+test -f .claude/settings.json && echo "hooks in place" || echo "WARNING: no hooks"
 
 # 3. Append to CLAUDE.md
 cat /path/to/nightshift-setup/CLAUDE-nightshift.md >> CLAUDE.md
@@ -552,6 +560,23 @@ git add -A && git commit -m "Checkpoint before Nightshift"
 ./nightshift-run.sh                                        # Foreground
 ./nightshift-run-bg.sh                                     # Background
 sandbox-exec -f nightshift-sandbox.sb ./nightshift-run.sh  # With sandbox
+```
+
+## Existing .claude/settings.json
+
+Copying would drop your own hooks, permissions, and MCP settings. Merge instead.
+The command keeps your entries and appends the Nightshift hooks per event type:
+
+```bash
+jq -s '(.[0].hooks // {{}}) as $mine | (.[1].hooks // {{}}) as $new
+       | (.[0] * .[1])
+       | .hooks = (reduce (($mine | to_entries[]), ($new | to_entries[])) as $e
+                   ({{}}; .[$e.key] = ((.[$e.key] // []) + $e.value)))' \\
+  .claude/settings.json /path/to/nightshift-setup/.claude/settings.json \\
+  > .claude/settings.merged.json
+
+# read it, then take it over
+mv .claude/settings.merged.json .claude/settings.json
 ```
 
 ## Risk Checks ({GENRE})

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -372,14 +372,18 @@ if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
 fi
 echo $$ > "$PIDFILE"
 
-# Graceful Shutdown
+# Graceful Shutdown, Exit-Code bleibt erhalten
 cleanup() {{
+    RC=${{1:-$?}}
+    trap - EXIT
     echo ""
-    echo "⏹  Nightshift wird beendet... ($(date))"
+    echo "⏹  Nightshift wird beendet (Exit-Code $RC)... ($(date))"
     rm -f "$PIDFILE"
-    exit 0
+    exit "$RC"
 }}
-trap cleanup SIGTERM SIGINT EXIT
+trap 'cleanup 143' SIGTERM
+trap 'cleanup 130' SIGINT
+trap cleanup EXIT
 
 LOGFILE="/tmp/nightshift-$(date +%Y%m%d-%H%M%S).log"
 echo "=== Claude Nightshift Start: $(date) ===" | tee "$LOGFILE"
@@ -401,6 +405,7 @@ if ! git diff --quiet 2>/dev/null || ! git diff --staged --quiet 2>/dev/null; th
     echo "⚠️  Uncommitted changes gefunden. Empfehlung: git stash"
 fi
 
+CLAUDE_RC=0
 claude -p \\
   "Lies runbook.md und arbeite alle Punkte sequentiell ab. \\
    Hake jeden erledigten Schritt mit [x] ab. \\
@@ -409,10 +414,15 @@ claude -p \\
    Am Ende: git add -A && git commit -m '{AUFGABE_KURZ}'" \\
   --dangerously-skip-permissions \\
   --output-format stream-json \\
-  2>&1 | tee -a "$LOGFILE"
+  2>&1 | tee -a "$LOGFILE" || CLAUDE_RC=$?
 
 echo ""
-echo "=== Claude Nightshift Ende: $(date) ===" | tee -a "$LOGFILE"
+if [ "$CLAUDE_RC" -eq 0 ]; then
+    echo "=== Claude Nightshift Ende: $(date) ===" | tee -a "$LOGFILE"
+else
+    echo "=== Claude Nightshift ABGEBROCHEN: $(date) (Exit-Code $CLAUDE_RC) ===" | tee -a "$LOGFILE"
+fi
+exit $CLAUDE_RC
 """
 
 RUN_BG_SH = f"""#!/bin/bash

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -247,6 +247,19 @@ GENRE_TEMPLATES = {
 # ════════════════════════════════════════════════════════════
 
 # ── PreToolUse-Hook: rote Zone ──────────────────────────────
+# Das Muster wird im Hook einfach gequotet, damit Backslashes
+# unveraendert bei grep ankommen. Die rm-Regel trifft gefaehrliche
+# Ziele (Wurzel, Home, Globs, Elternpfade, Systemordner, .git),
+# nicht jedes rm -rf: "rm -rf node_modules" bleibt erlaubt.
+BLOCK_PATTERN = (
+    "rm +(-[A-Za-z-]+ +)*("
+    "/( |$)|/\\*|~|\\$HOME|\\*|\\.\\.|\\./\\*|\\.( |$)|\\.git( |/|$)"
+    "|/(bin|boot|dev|etc|home|lib|opt|private|root|sbin|sys|usr|var"
+    "|Applications|Library|System|Users|Volumes)( |/|$)"
+    ")"
+    "|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\|.*bash|eval |> /dev/sd"
+)
+
 # Ohne jq kann der Hook nichts pruefen. Dann blockt er und sagt warum,
 # statt still durchzuwinken (fail closed).
 BLOCK_CMD = (
@@ -257,12 +270,13 @@ BLOCK_CMD = (
     "INPUT=$(cat); "
     'CMD=$(printf "%s" "$INPUT" | jq -r ".tool_input.command // empty") || '
     '{ echo "NIGHTSHIFT BLOCKED: jq konnte die Eingabe nicht lesen" >&2; exit 2; }; '
-    'if [ -n "$CMD" ] && printf "%s" "$CMD" | '
-    "grep -qE \"rm -rf /|rm -rf ~|rm -rf \\\\\\\\*|mkfs|dd if=.* of=/dev/|sudo |chmod 777|curl.*\\\\|.*bash|eval |> /dev/sd\"; then "
+    'if [ -n "$CMD" ] && printf "%s" "$CMD" | grep -qE '
+    "'\\''" + BLOCK_PATTERN + "'\\''; then "
     'echo "NIGHTSHIFT BLOCKED: Destruktiver Befehl" >&2; exit 2; '
     "fi; "
     "exit 0'"
 )
+
 
 SETTINGS = {
     "hooks": {


### PR DESCRIPTION
## Was geaendert wurde

Acht Commits auf `fix/welle-2`, jeweils eine Reparatur pro Commit.

### 1. Generator laeuft wieder unter dem System-Python

`nightshift/scripts/build_zip.py` hatte in Zeile 586 einen Backslash im Ausdrucksteil eines f-Strings. Das ist erst ab Python 3.12 erlaubt (PEP 701), darunter scheitert schon das Parsen. Das System-Python von macOS ist 3.9.6, und README wie SKILL.md verlangten nur "python3" ohne Version. Wer der eigenen Anleitung folgte und kein Homebrew-Python hatte, bekam keinen ZIP, sondern einen Traceback. Das Muster steht jetzt in einer eigenen Variablen. Mindestversion ist Python 3.9, dokumentiert in README, den vier Guides, beiden SKILL.md und auf der Landingpage.

`24x7/scripts/build_zip.py` baute die ZIP auf Modulebene. Jeder Import loeste damit einen Schreibvorgang nach `/mnt/user-data/outputs/` aus. Der Block liegt jetzt unter `if __name__ == "__main__"`, wie beim Nightshift-Zwilling.

### 2. Die vier Fehler in der Sicherheitsschicht

Alle vier stecken in Strings innerhalb der Generatoren, geaendert ist deshalb der Generator, nicht ein erzeugtes Artefakt.

**Hook faellt ohne jq offen aus.** Der Hook las das Kommando mit `cat | jq -r`. Fehlte jq, blieb `CMD` leer, die Bedingung `[ -n "$CMD" ]` war falsch, und der Hook endete mit exit 0. Er prueft jetzt zuerst auf jq und blockt mit exit 2 und Meldung, wenn es fehlt oder die Eingabe nicht lesbar ist.

**Block-Regex traf jedes rm -rf.** `rm -rf \\\\*` kam nach JSON- und Shell-Aufloesung bei grep als `rm -rf \*` an, also "rm -rf " gefolgt von null oder mehr Backslashes. Damit war auch `rm -rf node_modules` geblockt und ein Nachtlauf blieb an gewoehnlichen Aufraeumbefehlen haengen. Das Muster steht jetzt in einer Konstante und wird im Hook einfach gequotet, damit Backslashes unveraendert ankommen. Getroffen werden Wurzel, Home und dessen direkte Kinder, Globs, Elternpfade, Systemordner und `.git`. Projektlokale Ziele laufen durch, auch mit absolutem Praefix.

**nightshift-run.sh lieferte immer 0.** `cleanup()` endete mit `exit 0` und hing per trap an SIGTERM, SIGINT und EXIT. Jeder Fehlerpfad wurde als Erfolg gemeldet. `cleanup()` uebernimmt jetzt den Status, unter dem es aufgerufen wurde, die Signal-Traps setzen 143 und 130, und der Exit-Code des claude-Aufrufs wird eingesammelt, protokolliert und weitergegeben.

**24x7-Runner brauchte timeout.** Auf macOS ohne coreutils gibt es das Kommando nicht, der Aufruf lieferte 127, und weil der Task-Zweig kein sleep hat, wanderte eine gefuellte Inbox in Sekunden nach `failed/`. Der Runner bestimmt jetzt beim Start `TIMEOUT_BIN` aus `timeout` oder `gtimeout` und bricht sonst mit exit 1 und Installationshinweis ab. Die Pruefung steht vor dem PID-Lock, damit keine verwaiste PID-Datei zurueckbleibt. Die Prerequisites in README, beiden 24x7-Guides und auf der Landingpage nennen die Abhaengigkeit jetzt.

### 3. Installationsbefehl

`cp -r 24x7-setup/* WORKSPACE/` liess `.claude` aus, weil das Glob keine Dotfiles erfasst. Im 24x7-Workspace fehlte damit die gesamte Hook-Konfiguration, und der Daemon lief mit `--dangerously-skip-permissions` ohne PreToolUse-Block und ohne Heartbeat. Der Nightshift-Quickstart auf index.html hatte denselben Fehler.

Umgekehrt kopierte `cp -r nightshift-setup/.claude .` eine vorhandene `settings.json` weg, obwohl SKILL.md "merge hooks, never overwrite" zusagt. Der Schritt kommt vor dem Checkpoint-Commit, der Verlust war also auch ueber git nicht zurueckzuholen.

Der Installationsblock kopiert `.claude` jetzt in einem eigenen Schritt, bricht bei vorhandener `settings.json` mit Meldung ab und prueft am Ende, ob die Hooks angekommen sind. Fuer den Abbruchfall steht ein jq-Merge daneben, der eigene Hooks, Permissions und MCP-Einstellungen behaelt und die neuen Hooks je Ereignistyp anhaengt. Geaendert in README, allen vier Guides, auf index.html und in beiden generierten Setup-READMEs.

## Wie geprueft

Jeder Befund wurde vor der Reparatur nachgestellt.

- `python3 -m py_compile` auf beide Generatoren mit `/usr/bin/python3` (3.9.6): exit 0. Vorher SyntaxError in Zeile 586.
- Testreihe mit 28 Block- und 18 Durchlassfaellen plus zwei jq-Faellen gegen beide Hooks, ueber den echten Weg `json.dumps` nach Datei, zurueck lesen, an `sh -c` geben. Alle 48 Faelle bestanden fuer beide Generatoren. Ohne jq im PATH: exit 2 mit Meldung. `rm -rf node_modules`, `rm -rf dist`, `rm -f *.log`, `rm -rf /Users/ich/projekt/dist`, `rm -f .git/index.lock`: exit 0. `rm -rf /`, `rm -rf ~`, `rm -rf /Users/ich`, `rm -rf .git`, `rm -rf */`: exit 2.
- `nightshift-run.sh` mit claude-Stub: Absturz mit 42 liefert 42, Erfolg liefert 0, SIGTERM liefert 143 und raeumt die PID-Datei ab.
- 24x7-Runner ohne `timeout` und ohne `gtimeout`: exit 1 mit Hinweis, keine PID-Datei. Mit einem gtimeout-Stub: Start meldet "via gtimeout", ein Task wird abgearbeitet und landet in `outbox/`.
- Installationsblock in einem Scratch-Workspace: alter Befehl laesst `.claude` weg, neuer Befehl kopiert es, eine vorhandene `settings.json` bleibt byteweise unveraendert. Der jq-Merge behaelt `permissions` und einen eigenen PreToolUse-Hook und haengt die neuen Hooks an.
- `bash -n` auf beide generierten Shell-Skripte.

## Was offen bleibt

- `ZIP_PATH` ist in beiden Generatoren weiterhin fest auf `/mnt/user-data/outputs/` verdrahtet. Ein Lauf von Anfang bis ZIP war hier deshalb nicht moeglich, geprueft wurden die erzeugten Artefakte ueber den Import der Module. Die Parametrisierung gehoert in eine eigene Aenderung.
- Das Muster bleibt Pattern-Matching auf der Kommandozeile, keine Grenze. `time rm -rf /` oder `R=rm; $R -rf /` gehen durch. Bekannter Fehlalarm in der Gegenrichtung: `git rm -r --cached .` wird geblockt, weil `rm` nicht an den Kommandoanfang gebunden ist. Eine Bindung wuerde die erste Umgehung erlauben, deshalb bleibt es so.
- Die Zusage in `nightshift/SKILL.md`, der Hook blocke Fork-Bomben, stimmt weiterhin nicht. Kein Muster dafuer vorhanden, ausserhalb dieses Auftrags.
- `cleanup()` im 24x7-Runner endet weiterhin mit exit 0 und gibt beim Beenden per SIGTERM zweimal dieselbe Zeile aus.
- `index.html` ist ab Zeile 1352 abgeschnitten, `</footer>`, `</body>` und `</html>` fehlen. Vorbestehend, nicht angefasst.
- Docker-Isolation, Cost Governor und Morning Receipt sind ausdruecklich Welle 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

## Nacharbeit nach der Abnahme

Die erste Fassung des reparierten rm-Musters war fuer gequotete Ziele schlechter als der
kaputte Ausdruck davor: `rm -rf "/"` lief durch, waehrend der alte, zerfallene Ausdruck es
noch geblockt hatte. Pfade mit Variablen quotet ein Modell von sich aus, das ist der Normalfall.
Behoben im Generator, danach gemessen: alle 18 gequoteten Varianten der neun gefaehrlichen
Ziele kippen von Exit 0 auf Exit 2, in beiden Generatoren mit identischen Codes. Die harmlosen
Faelle laufen weiter durch.

## Was bewusst offen bleibt

- Das Muster prueft nur das erste Nicht-Flag-Argument. `rm -rf build dist "$HOME"` laeuft durch.
  Das galt vorher genauso und ist keine Folge dieser Aenderung.
- `rm -rf "$PWD"` und `rm -rf "$(pwd)"` laufen durch, das Muster kennt nur `$HOME` und `~`.
- Auf dem dokumentierten Startweg meldet der 24x7-Runner ein fehlendes `timeout` nicht.
- Die Home-Regel wirkt relativ, nicht absolut: `rm -rf ~/Downloads` blockt,
  `rm -rf /Users/<name>/Downloads` nicht.

Docker-Isolation, Cost Governor und Morning Receipt sind nicht Teil dieses PR.


---
Teil von Welle 2 des Haerteplans: erst lauffaehig, dann sichtbar. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die Pruefungen selbst wiederholt hat.
