### PR TITLE
CI sichtbar machen und Aussagen richtigstellen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pruefen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 3.9 ist die dokumentierte Untergrenze und das System-Python von macOS.
+      # Eine neuere Version wuerde genau die Syntaxfehler durchwinken, an denen
+      # Nutzer mit dem System-Python haengen bleiben.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Generatoren unter Python 3.9 kompilieren
+        run: python -m py_compile nightshift/scripts/build_zip.py 24x7/scripts/build_zip.py
+
+      - name: Generatoren ausfuehren und ZIP-Inhalt pruefen
+        run: python -m unittest discover -s tests -p 'test_generatoren.py' -v
+
+      - name: Blockmuster des PreToolUse-Hooks pruefen
+        run: python -m unittest discover -s tests -p 'test_block_muster.py' -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/24x7-guide_de.md
+++ b/24x7-guide_de.md
@@ -238,7 +238,7 @@ chmod +x *.sh
 
 Zeigt alle 60 Sekunden den Status:
 ```
-✅ 14:32:01: OK (12s) | inbox: 3 | working: 1 | done: 8 | failed: 0
+✅ 14:32:01: OK (12s) | 📥3 🔄1 ✅8 ❌0
 ```
 
 ### Task einwerfen (jederzeit)

--- a/24x7-guide_en.md
+++ b/24x7-guide_en.md
@@ -342,7 +342,7 @@ Each task gets a fresh Claude session. Claude does not remember the previous tas
 Default: 60 minutes. Tasks taking longer are killed and moved to `failed/`. Adjust `MAX_SECONDS` in `runner.sh` if needed.
 
 ### Workspace Isolation
-Claude can only work within the workspace. The CLAUDE.md rules and the sandbox enforce this. Claude cannot access your home directory, other projects, or the internet (except the Anthropic API).
+Writes are the part that holds: with the sandbox profile active, Claude can only write to the workspace and /tmp. Everything else is an agreement in CLAUDE.md, not enforcement. The profile grants read access to `$HOME/.claude` and `$HOME/.config`, and it allows outbound TCP on port 443 to any host, so reads outside the workspace and traffic to arbitrary endpoints are possible. Without `sandbox-exec` even the write restriction is gone.
 
 ---
 

--- a/24x7-guide_en.md
+++ b/24x7-guide_en.md
@@ -266,9 +266,9 @@ Stop:     kill 12345
 
 Shows live status every 60 seconds:
 ```
-✅ 14:32:01: OK (12s) | inbox: 3 | working: 1 | done: 8 | failed: 0
-✅ 14:33:01: OK (5s)  | inbox: 2 | working: 1 | done: 8 | failed: 0
-✅ 14:34:01: OK (3s)  | inbox: 2 | working: 0 | done: 9 | failed: 0
+✅ 14:32:01: OK (12s) | 📥3 🔄1 ✅8 ❌0
+✅ 14:33:01: OK (5s) | 📥2 🔄1 ✅8 ❌0
+✅ 14:34:01: OK (3s) | 📥2 🔄0 ✅9 ❌0
 ```
 
 ### Drop a Task While Running

--- a/24x7/SKILL.md
+++ b/24x7/SKILL.md
@@ -112,7 +112,7 @@ python3 /home/claude/build_24x7.py
 | runner.sh | Endless loop: poll inbox, spawn Claude, route results. PID lock + graceful shutdown. |
 | runner-bg.sh | Background starter (nohup wrapper) |
 | watchdog.sh | Heartbeat monitor with live status: 📥inbox 🔄working ✅done ❌failed |
-| sandbox.sb | macOS sandbox profile — restricts filesystem to workspace + /tmp |
+| sandbox.sb | macOS sandbox profile: restricts writes to workspace + /tmp. Reads outside the workspace and outbound traffic on 443 stay open. |
 | .claude/settings.json | Hooks: PreToolUse (security), PostToolUse (heartbeat) |
 | CLAUDE.md | Workspace rules: isolation, autonomy zones, error tolerance, workspace memory |
 | idle/idle-tasks.md | Configurable idle behavior |
@@ -138,7 +138,7 @@ Format: date, task name, decision, reasoning. Append-only.
 
 ## Security
 
-- All work is confined to the workspace — no external paths allowed
+- The workspace boundary is a rule in CLAUDE.md, not something the setup enforces. The hook checks no paths and never sees Write or Edit, and without a running sandbox profile nothing stops a write elsewhere.
 - PreToolUse hook blocks a fixed list of command patterns: rm against dangerous targets (root, home and its direct children, globs, parent paths, .git, system directories), mkfs, dd writing to a device, sudo, chmod 777, curl piped into bash, eval. Fork bombs are not on that list, there is no pattern for them.
 - The hook carries `"matcher": "Bash"` and greps the command text, so Write and Edit never reach it. It is a typo catcher, not a boundary. See [SECURITY.md](../SECURITY.md).
 - Sandbox profile restricts writes to workspace + /tmp at kernel level. Reads outside the workspace and outbound network traffic are not restricted.

--- a/24x7/SKILL.md
+++ b/24x7/SKILL.md
@@ -139,8 +139,9 @@ Format: date, task name, decision, reasoning. Append-only.
 ## Security
 
 - All work is confined to the workspace — no external paths allowed
-- PreToolUse hook blocks: rm -rf, mkfs, dd, sudo, chmod 777, curl-pipe-bash, eval, fork bombs
-- Sandbox profile restricts filesystem to workspace + /tmp at kernel level
+- PreToolUse hook blocks a fixed list of command patterns: rm against dangerous targets (root, home and its direct children, globs, parent paths, .git, system directories), mkfs, dd writing to a device, sudo, chmod 777, curl piped into bash, eval. Fork bombs are not on that list, there is no pattern for them.
+- The hook carries `"matcher": "Bash"` and greps the command text, so Write and Edit never reach it. It is a typo catcher, not a boundary. See [SECURITY.md](../SECURITY.md).
+- Sandbox profile restricts writes to workspace + /tmp at kernel level. Reads outside the workspace and outbound network traffic are not restricted.
 - PID lock prevents duplicate runner instances
 - Task timeout prevents infinite loops
 - **Cost warning:** 24/7 operation generates continuous API calls. Set idle to "sleep" if cost is a concern. Monitor the Anthropic dashboard.

--- a/24x7/scripts/build_zip.py
+++ b/24x7/scripts/build_zip.py
@@ -595,7 +595,10 @@ Autonomy zones and error tolerance inspired by [AlpiType — Solving the AI Agen
 # ════════════════════════════════════════════════════════════
 
 if __name__ == "__main__":
-    ZIP_PATH = "/mnt/user-data/outputs/24x7-setup.zip"
+    # Zielpfad ueberschreibbar, damit der Generator auch ausserhalb der
+    # Claude-Umgebung schreiben kann (Tests, CI, lokale Laeufe).
+    ZIP_PATH = os.environ.get("CLAUDE_24X7_OUT", "/mnt/user-data/outputs/24x7-setup.zip")
+    os.makedirs(os.path.dirname(ZIP_PATH) or ".", exist_ok=True)
 
     idle_content = IDLE_TASKS.get(IDLE_BEHAVIOR, IDLE_TASKS["sleep"])
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Claude Code hooks are scripts that fire on specific events:
 Hooks fire even with `--dangerously-skip-permissions`. A `PreToolUse` hook returning exit code 2 blocks the tool call unconditionally.
 
 **Layer 3: macOS Sandbox (Kernel-Level Isolation)**
-A `sandbox-exec` profile that restricts Claude's filesystem access at the kernel level. Claude can only write to the project directory and `/tmp`. Even if Claude tries `rm -rf ~/`, the kernel blocks it — the hook doesn't even need to catch it. This is the real safety net.
+A `sandbox-exec` profile that restricts Claude's filesystem access at the kernel level. Claude can only write to the project directory and `/tmp`. Even if Claude tries `rm -rf ~/`, the kernel blocks it, without the hook having to catch it. This is the only layer a kernel enforces, and it enforces writes: reads outside the project and outbound network traffic stay open. See [What the Sandbox Does Not Cover](#what-the-sandbox-does-not-cover) and [SECURITY.md](SECURITY.md).
 
 Note: `sandbox-exec` is deprecated by Apple but still functional on current macOS versions. It uses Seatbelt, a kernel-level sandbox framework.
 
@@ -424,15 +424,32 @@ The generated `sandbox.sb` / `nightshift-sandbox.sb` file is just a profile. You
 sandbox-exec -f nightshift-sandbox.sb ./nightshift-run.sh
 ```
 
-Without `sandbox-exec`, Claude has full access to everything your user account can reach. The `PreToolUse` hook catches obvious destructive commands, but it's pattern-matching — not a real security boundary. The sandbox is the real security boundary.
+Without `sandbox-exec`, Claude has full access to everything your user account can reach. The `PreToolUse` hook greps the command text, so it catches typos and obvious mistakes. It carries `"matcher": "Bash"`, which means `Write` and `Edit` never reach it.
 
-On Linux, there is no `sandbox-exec`. Use Docker or a dedicated user account instead:
+### What the Sandbox Does Not Cover
+
+The sandbox is the only layer that a kernel enforces, and what it enforces is writes. It restricts neither reads nor network traffic. The generated profile grants `file-read*` on `$HOME/.claude` and `$HOME/.config`, and it allows `(allow network-outbound (remote tcp "*:443"))` without a destination. `~/.claude` holds the transcripts of your other projects, `~/.config` commonly holds CLI tokens. Anything the run can read, it can also send.
+
+Calling the sandbox a security boundary is only accurate for writes to the filesystem. [SECURITY.md](SECURITY.md) has the threat model, the trust boundaries, and the list of known gaps.
+
+### Linux Has No sandbox-exec
+
+Docker with the project mounted is the route that gives you an enforced boundary. A dedicated user account scopes file access with Unix permissions, which is weaker and takes more than three lines:
 
 ```bash
 sudo useradd -m clauderunner
 sudo cp -r /your/project /home/clauderunner/project
-sudo -u clauderunner ./nightshift-run.sh
+sudo chown -R clauderunner: /home/clauderunner/project
+sudo -u clauderunner /home/clauderunner/project/nightshift-run.sh
 ```
+
+Three things about that recipe:
+
+- The copy that `sudo cp -r` creates belongs to root. Without the `chown`, the runner account cannot write in its own working copy.
+- `nightshift-run.sh` starts with a `cd` to the path that was set when the setup was generated. Regenerate the setup with `NIGHTSHIFT_PROJECT=/home/clauderunner/project`, otherwise the run leaves the new account and works in the original directory.
+- The new account has no Claude Code credentials. Authenticate as that user once before the first run.
+
+Even then the account reaches the network and can read every world-readable file on the machine. This is permission scoping, not isolation.
 
 ### Git Is Your Undo Button (Nightshift)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Nightshift & 24x7 — Autonomous Claude Code Skills
 
+[![CI](https://github.com/GodModeAI2025/NightShift/actions/workflows/ci.yml/badge.svg)](https://github.com/GodModeAI2025/NightShift/actions/workflows/ci.yml)
+
 Two skills that turn Claude Code from an interactive tool into an autonomous worker. Nightshift runs planned project work overnight. 24x7 runs an endless task queue.
 
 **Landing page:** [godmodeai2025.github.io/NightShift](https://godmodeai2025.github.io/NightShift/)

--- a/README.md
+++ b/README.md
@@ -527,6 +527,26 @@ kill $(cat /tmp/24x7.pid)
 
 ---
 
+## Roadmap
+
+Ordered by what blocks users today. No dates attached, this is a private project.
+
+**Next**
+
+- **Release assets.** The install commands under [Install the Skills](#install-the-skills) point at `releases/latest/download/nightshift.skill` and `24x7.skill`. There is no release and no tag, so the documented install path returns 404. Packaging both directories and tagging a version needs no code change.
+- **A hook that sees more than Bash.** The `PreToolUse` hook carries `"matcher": "Bash"`. `Write` and `Edit` bypass it entirely, and a variable assignment gets past the pattern. A second matcher plus a path check instead of a string match.
+- **Egress control.** The seatbelt profile allows outbound 443 to any host. Restricting it to the Anthropic API is what turns a write boundary into something closer to a real one.
+
+**After that**
+
+- **Linux isolation that holds.** A Docker Compose setup with the project mounted, so the Linux route stops being a user-account workaround.
+- **A cost ceiling that stops a run.** Both runners print a warning at startup and that is the entire mechanism. Nightshift has no timeout at all.
+- **A morning receipt.** One JSON file per run: steps done against steps open, `git diff --stat`, the decisions log, the exit code.
+
+**Test coverage**
+
+CI compiles both generators under Python 3.9, runs them, checks the generated ZIP, and drives the block list of the `PreToolUse` hook against a table of dangerous and harmless commands. The generated shell scripts are only checked for syntax; nothing executes a runner, a watchdog, or the sandbox profile. See [.github/workflows/ci.yml](.github/workflows/ci.yml) and [tests/](tests).
+
 ## Acknowledgments
 
 Autonomy zones and error budget inspired by [AlpiType — Solving the AI Agent Approval Loop](https://alpitype.de/insights/ki-agenten-approval-loop/)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A markdown file with checkboxes that Claude reads before each step. After contex
 
 **Layer 2: Hooks (Guardrails)**
 Claude Code hooks are scripts that fire on specific events:
-- `PreToolUse` — Runs before every tool call. Blocks destructive commands like `rm -rf /`, `sudo`, `chmod 777`, `curl | bash`, `eval`.
+- `PreToolUse` — Carries `"matcher": "Bash"`, so it runs before every Bash call and never sees `Write` or `Edit`. Blocks command patterns like `rm -rf /`, `sudo`, `chmod 777`, `curl | bash`, `eval`.
 - `PostToolUse` — Runs after every tool call. Writes a heartbeat timestamp to a log file.
 - `SessionStart` (compact matcher) — Fires after every context compression. Injects "re-read the runbook" into Claude's context.
 - `Stop` (Nightshift only) — Fires every time Claude finishes a response. Every 5 completed steps, reminds Claude of autonomy zones and error budget.
@@ -120,7 +120,7 @@ Before generating the setup, the skill validates the runbook against 15 checks:
 
 **Autonomy:** Has all three zones (green/yellow/red)? Has error budget? Error budget has a stop condition?
 
-The setup is only generated when all 15 checks pass — or when you explicitly override.
+Validation is not a gate. The generator prints the score and writes the ZIP even when checks fail, so a failed check is a prompt to fix the runbook, not a stop.
 
 ### Checkpoint Repetition
 
@@ -162,17 +162,13 @@ The 24x7 skill uses the same pattern at workspace level: each task reads `decisi
 
 ### Install the Skills
 
+There is no release and no tag yet, so there is no `.skill` file to download. Clone the repo and copy both skill directories:
+
 ```bash
-# Download and install Nightshift
-curl -L https://github.com/GodModeAI2025/NightShift/releases/latest/download/nightshift.skill -o nightshift.skill
-unzip nightshift.skill -d ~/.claude/skills/
-
-# Download and install 24x7
-curl -L https://github.com/GodModeAI2025/NightShift/releases/latest/download/24x7.skill -o 24x7.skill
-unzip 24x7.skill -d ~/.claude/skills/
+git clone https://github.com/GodModeAI2025/NightShift.git
+mkdir -p ~/.claude/skills
+cp -r NightShift/nightshift NightShift/24x7 ~/.claude/skills/
 ```
-
-Or manually: download the `nightshift/` and `24x7/` directories from this repo and place them in `~/.claude/skills/`.
 
 ### Verify Installation
 
@@ -384,7 +380,7 @@ The runner picks it up automatically. Results appear in `outbox/my-task/output/`
 ./watchdog.sh
 ```
 
-Shows live status: `inbox: 3 | working: 1 | done: 12 | failed: 0`
+Shows live status: `✅ 14:32:01: OK (12s) | 📥3 🔄1 ✅12 ❌0`
 
 ### Step 5: Collect Results
 
@@ -523,7 +519,7 @@ kill $(cat /tmp/24x7.pid)
 | `.claude/settings.json` | PreToolUse + PostToolUse hooks |
 | `CLAUDE.md` | Workspace rules: autonomy zones, error tolerance, workspace memory (decisions.md) |
 | `idle/idle-tasks.md` | Configurable idle behavior |
-| `inbox/example-task/` | Example task with task.md template |
+| `inbox/beispiel-task/` | Example task with task.md template |
 
 ---
 
@@ -533,7 +529,7 @@ Ordered by what blocks users today. No dates attached, this is a private project
 
 **Next**
 
-- **Release assets.** The install commands under [Install the Skills](#install-the-skills) point at `releases/latest/download/nightshift.skill` and `24x7.skill`. There is no release and no tag, so the documented install path returns 404. Packaging both directories and tagging a version needs no code change.
+- **Release assets.** Installing means cloning the repo and copying two directories, because there is no release and no tag. Packaging `nightshift/` and `24x7/` as downloadable assets and tagging a version needs no code change.
 - **A hook that sees more than Bash.** The `PreToolUse` hook carries `"matcher": "Bash"`. `Write` and `Edit` bypass it entirely, and a variable assignment gets past the pattern. A second matcher plus a path check instead of a string match.
 - **Egress control.** The seatbelt profile allows outbound 443 to any host. Restricting it to the Anthropic API is what turns a write boundary into something closer to a real one.
 

--- a/index.html
+++ b/index.html
@@ -1013,7 +1013,7 @@
       <div class="security-layer">
         <div class="num">1</div>
         <h4>PreToolUse Hook</h4>
-        <p>Blocks rm -rf, sudo, mkfs, chmod 777, curl|bash, eval, fork bombs</p>
+        <p>Blocks rm against dangerous targets, sudo, mkfs, dd to a device, chmod 777, curl|bash, eval. No pattern for fork bombs.</p>
       </div>
       <div class="security-layer">
         <div class="num">2</div>
@@ -1052,7 +1052,7 @@
     <div class="layer-detail">
       <h4><span class="badge">Layer 2</span> Hooks — Automated Guardrails</h4>
       <p>Claude Code hooks are scripts that fire on specific events. They run even with <code>--dangerously-skip-permissions</code>. A PreToolUse hook returning exit code 2 blocks the tool call unconditionally — Claude cannot override it.</p>
-      <div class="code-example"><span style="color:var(--accent-amber)">PreToolUse</span>    → Blocks rm -rf, sudo, mkfs, chmod 777, curl|bash, eval
+      <div class="code-example"><span style="color:var(--accent-amber)">PreToolUse</span>    → Blocks rm against dangerous targets, sudo, mkfs, dd, chmod 777, curl|bash, eval
 <span style="color:var(--accent-green)">PostToolUse</span>   → Writes heartbeat timestamp after every tool call
 <span style="color:var(--accent-night-glow)">SessionStart</span>  → After /compact: "Re-read runbook.md, continue at next open item"
 <span style="color:var(--accent-24x7-glow)">Stop</span>          → Every 5 steps: repeat constraints. 3× no progress: STALL WARNING</div>
@@ -1060,7 +1060,8 @@
 
     <div class="layer-detail">
       <h4><span class="badge">Layer 3</span> macOS Sandbox — Kernel-Level Isolation</h4>
-      <p>A <code>sandbox-exec</code> profile restricts Claude's filesystem access at the kernel level. Claude can only write to the project directory and /tmp. Even if Claude tries <code>rm -rf ~/</code>, the kernel blocks it — the hook doesn't even need to catch it. This is the real safety net, not the hook.</p>
+      <p>A <code>sandbox-exec</code> profile restricts Claude's filesystem access at the kernel level. Claude can only write to the project directory and /tmp. Even if Claude tries <code>rm -rf ~/</code>, the kernel blocks it, without the hook having to catch it.</p>
+      <p style="margin-top: 12px;">What the profile does not restrict: reads and network traffic. It grants <code>file-read*</code> on <code>$HOME/.claude</code> and <code>$HOME/.config</code>, and it allows outbound TCP on port 443 to any host. Your other projects' transcripts sit in the first directory, CLI tokens commonly in the second. Anything the run can read, it can also send. Call it a write boundary, not a security boundary. The <a href="https://github.com/GodModeAI2025/NightShift/blob/main/SECURITY.md">security policy</a> has the threat model.</p>
       <p style="margin-top: 12px;"><strong>Important:</strong> The sandbox is not active by default. You must explicitly start with <code>sandbox-exec -f sandbox.sb ./run.sh</code>. Without it, Claude has full access to everything your user account can reach. On Linux, use Docker or a dedicated user account instead.</p>
     </div>
 
@@ -1203,7 +1204,7 @@
 
     <div class="warning">
       <h4>The Sandbox Is Not Active by Default</h4>
-      <p>The generated sandbox profile is just a file. You must explicitly start with <code>sandbox-exec -f sandbox.sb ./run.sh</code>. Without it, Claude has full access to your entire user account. The PreToolUse hook catches obvious destructive commands via pattern matching, but it's not a real security boundary — the sandbox is. On Linux, use Docker or a dedicated user account instead of sandbox-exec.</p>
+      <p>The generated sandbox profile is just a file. You must explicitly start with <code>sandbox-exec -f sandbox.sb ./run.sh</code>. Without it, Claude has full access to your entire user account. The PreToolUse hook matches command text and only sees Bash, so Write and Edit pass it untouched. With the profile active, writes outside the project are blocked; reads and outbound traffic are not. Details in the <a href="https://github.com/GodModeAI2025/NightShift/blob/main/SECURITY.md">security policy</a>. On Linux there is no sandbox-exec, see the note below.</p>
     </div>
 
     <div class="warning">
@@ -1218,7 +1219,7 @@
 
     <div class="warning">
       <h4>macOS Only for Sandbox</h4>
-      <p><code>sandbox-exec</code> is a macOS-only feature (deprecated but functional). On Linux, run Claude inside a Docker container with mounted volumes, or create a dedicated user account with limited permissions. The hooks and watchdog work on any platform — only the kernel-level sandbox is macOS-specific.</p>
+      <p><code>sandbox-exec</code> is a macOS-only feature (deprecated but functional). On Linux, run Claude inside a Docker container with mounted volumes. A dedicated user account is the weaker fallback, and the short recipe that used to stand in the README does not work: the copy made with <code>sudo cp -r</code> belongs to root, and the generated <code>nightshift-run.sh</code> carries a hardcoded <code>cd</code> into the directory that was set when the setup was generated. The <a href="https://github.com/GodModeAI2025/NightShift#linux-has-no-sandbox-exec">README</a> has the corrected steps. The hooks and watchdog work on any platform, only the kernel-level sandbox is macOS-specific.</p>
     </div>
 
     <div class="warning">

--- a/index.html
+++ b/index.html
@@ -868,7 +868,7 @@
           24x7-setup
         </div>
         <div class="arch-panel-body"><span class="highlight-blue">inbox/</span>                 <span class="dim">← Drop tasks here</span>
-<span class="highlight-blue">  example-task/task.md</span>  <span class="dim">← Template</span>
+<span class="highlight-blue">  beispiel-task/task.md</span> <span class="dim">← Template</span>
 <span class="dim">working/</span>               <span class="dim">← Auto-populated</span>
 <span class="highlight-green">outbox/</span>                <span class="dim">← Collect results</span>
 <span class="highlight-amber">failed/</span>                <span class="dim">← Failed tasks</span>
@@ -1099,7 +1099,7 @@
         <div class="step-num">1</div>
         <div class="step-content">
           <h4>Install the Skill</h4>
-          <p>Download <code>nightshift.skill</code> and unzip it into Claude's skill directory: <code>unzip nightshift.skill -d ~/.claude/skills/</code>. This makes the skill available in Claude Code and Claude.ai. You only do this once.</p>
+          <p>There is no release to download yet. Clone the repo and copy the skill directory: <code>cp -r NightShift/nightshift ~/.claude/skills/</code>. This makes the skill available in Claude Code and Claude.ai. You only do this once.</p>
         </div>
       </div>
       <div class="step">
@@ -1155,7 +1155,7 @@
         <div class="step-num">1</div>
         <div class="step-content">
           <h4>Install and Generate</h4>
-          <p>Install the skill: <code>unzip 24x7.skill -d ~/.claude/skills/</code>. Then tell Claude: "Set up a 24x7 runner at /my/workspace with idle behavior cleanup". Claude generates the workspace structure with runner, watchdog, hooks, and sandbox.</p>
+          <p>Install the skill from a clone of the repo: <code>cp -r NightShift/24x7 ~/.claude/skills/</code>. Then tell Claude: "Set up a 24x7 runner at /my/workspace with idle behavior cleanup". Claude generates the workspace structure with runner, watchdog, hooks, and sandbox.</p>
         </div>
       </div>
       <div class="step">
@@ -1277,8 +1277,9 @@
         <div class="dot g"></div>
         <span>Install and run Nightshift</span>
       </div>
-      <div class="quickstart-body"><span class="comment"># Install skill</span>
-<span class="cmd">unzip</span> <span class="path">nightshift.skill</span> <span class="flag">-d</span> ~/.claude/skills/
+      <div class="quickstart-body"><span class="comment"># Install skill (no release yet, so clone)</span>
+<span class="cmd">git</span> clone <span class="path">https://github.com/GodModeAI2025/NightShift.git</span>
+<span class="cmd">cp</span> <span class="flag">-r</span> <span class="path">NightShift/nightshift</span> ~/.claude/skills/
 
 <span class="comment"># Tell Claude:</span>
 <span class="comment"># "Set up a Nightshift run for /my/project</span>
@@ -1315,8 +1316,9 @@
         <div class="dot g"></div>
         <span>Install 24x7 and drop a task</span>
       </div>
-      <div class="quickstart-body"><span class="comment"># Install skill</span>
-<span class="cmd">unzip</span> <span class="path">24x7.skill</span> <span class="flag">-d</span> ~/.claude/skills/
+      <div class="quickstart-body"><span class="comment"># Install skill (no release yet, so clone)</span>
+<span class="cmd">git</span> clone <span class="path">https://github.com/GodModeAI2025/NightShift.git</span>
+<span class="cmd">cp</span> <span class="flag">-r</span> <span class="path">NightShift/24x7</span> ~/.claude/skills/
 
 <span class="comment"># Tell Claude:</span>
 <span class="comment"># "Set up a 24x7 runner at /claude-workspace"</span>
@@ -1350,7 +1352,7 @@
 <footer class="footer">
   <div class="container">
     <p>Claude Nightshift & 24x7 — Autonomous Skills for Claude Code</p>
-    <p class="version">v1.0 · Apache-2.0 License · Compatible with Claude Code CLI · <a href="https://github.com/GodModeAI2025/NightShift" style="color: var(--text-muted); text-decoration: underline;">GitHub</a></p>
+    <p class="version">No tagged release yet · Apache-2.0 License · Compatible with Claude Code CLI · <a href="https://github.com/GodModeAI2025/NightShift" style="color: var(--text-muted); text-decoration: underline;">GitHub</a></p>
     <p style="margin-top: 20px; font-size: 13px; color: #555568;">Autonomy zones and error budget inspired by <a href="https://alpitype.de/insights/ki-agenten-approval-loop/" style="color: var(--text-muted); text-decoration: underline;">AlpiType — Solving the AI Agent Approval Loop</a></p>
     <p style="margin-top: 12px; font-size: 12px; color: #444458; max-width: 600px; margin-left: auto; margin-right: auto;">Disclaimer: This project was created privately, to the best of the author's knowledge. Use at your own risk. No warranty of completeness, correctness, or fitness for any particular purpose.</p>
 

--- a/nightshift-guide_de.md
+++ b/nightshift-guide_de.md
@@ -255,12 +255,14 @@ Vage Schritte erzeugen vage Ergebnisse. Prüfe das Runbook vor dem Start. Bei me
 Bei Runs über 20 Minuten passiert Kontextkomprimierung. Die Hooks fangen das ab, aber bei 30+ Schritten sinkt die Qualität. Unter 20 Schritte pro Run bleiben.
 
 ### Linux-Nutzer
-`sandbox-exec` gibt es nur auf macOS. Nutze Docker oder einen eigenen Benutzer:
+`sandbox-exec` gibt es nur auf macOS. Docker mit gemountetem Projekt ist der Weg, der eine durchgesetzte Grenze liefert. Ein eigener Benutzer schraenkt nur die Dateirechte ein und braucht drei Schritte mehr:
 ```bash
 sudo useradd -m clauderunner
 sudo cp -r /dein/projekt /home/clauderunner/projekt
-sudo -u clauderunner ./nightshift-run.sh
+sudo chown -R clauderunner: /home/clauderunner/projekt
+sudo -u clauderunner /home/clauderunner/projekt/nightshift-run.sh
 ```
+Die Kopie aus `sudo cp -r` gehoert sonst root, und der Runner kann in seinem eigenen Arbeitsverzeichnis nicht schreiben. Ausserdem steht im erzeugten `nightshift-run.sh` ein fester `cd` auf den Pfad, der beim Generieren gesetzt war: das Setup mit `NIGHTSHIFT_PROJECT=/home/clauderunner/projekt` neu erzeugen, sonst laeuft der Run wieder im Originalverzeichnis. Das neue Konto braucht eine eigene Claude-Code-Anmeldung.
 
 ---
 

--- a/nightshift-guide_de.md
+++ b/nightshift-guide_de.md
@@ -111,7 +111,7 @@ Claude validiert das Runbook gegen 15 Checks:
 - Sicherheit: Kein `rm -rf`? Keine hardcoded Secrets? Alle Pfade im Projekt?
 - Autonomie: Drei Zonen (grün/gelb/rot) definiert? Fehler-Budget mit Stop-Bedingung?
 
-Bei Fehlern schlägt Claude Fixes vor. Das Setup wird erst generiert wenn alle Checks bestehen.
+Bei Fehlern schlägt Claude Fixes vor. Der Generator schreibt die ZIP trotzdem. Ein fehlgeschlagener Check stoppt nichts, er ist ein Hinweis, das Runbook nachzubessern.
 
 ### 3.4 Setup-Dateien
 

--- a/nightshift-guide_en.md
+++ b/nightshift-guide_en.md
@@ -258,12 +258,14 @@ Vague steps produce vague results. Review the runbook before starting. If you ne
 On runs longer than 20 minutes, context compression happens. The hooks handle it, but for 30+ step runbooks, quality degrades. Stay under 20 steps per run.
 
 ### Linux Users
-`sandbox-exec` is macOS only. Use Docker or a dedicated user account:
+`sandbox-exec` is macOS only. Docker with the project mounted is the route that gives you an enforced boundary. A dedicated user account only scopes file permissions and needs three more steps:
 ```bash
 sudo useradd -m clauderunner
 sudo cp -r /your/project /home/clauderunner/project
-sudo -u clauderunner ./nightshift-run.sh
+sudo chown -R clauderunner: /home/clauderunner/project
+sudo -u clauderunner /home/clauderunner/project/nightshift-run.sh
 ```
+Without the `chown`, the copy belongs to root and the runner cannot write in its own working directory. The generated `nightshift-run.sh` also carries a hardcoded `cd` to the path set at generation time, so regenerate the setup with `NIGHTSHIFT_PROJECT=/home/clauderunner/project` or the run lands back in the original directory. The new account needs its own Claude Code login.
 
 ---
 

--- a/nightshift-guide_en.md
+++ b/nightshift-guide_en.md
@@ -59,7 +59,7 @@ The flag `--dangerously-skip-permissions` removes all approval prompts. But with
 Download the skill from the repository:
 
 ```bash
-# Option A: Download the .skill file
+# Download the skill definition (there is no .skill release)
 curl -L https://github.com/GodModeAI2025/NightShift/raw/main/nightshift/SKILL.md -o /tmp/nightshift-skill.md
 
 # Create the skill directory
@@ -114,7 +114,7 @@ Claude validates the runbook against 15 checks:
 - Safety: No `rm -rf`? No hardcoded secrets? All paths inside project?
 - Autonomy: Three zones (green/yellow/red) defined? Error budget with stop condition?
 
-If validation fails, Claude suggests fixes. The setup is only generated when all checks pass.
+If validation fails, Claude suggests fixes. The generator writes the ZIP either way, so a failed check is a prompt to fix the runbook, not a stop.
 
 ### 3.4 Setup Files
 

--- a/nightshift/SKILL.md
+++ b/nightshift/SKILL.md
@@ -168,8 +168,9 @@ The Stop hook tracks progress between checks. If the number of completed runbook
 
 ## Security
 
-- PreToolUse hook blocks: rm -rf, mkfs, dd, sudo, chmod 777, curl-pipe-bash, eval, fork bombs
-- Sandbox profile restricts filesystem access to project directory + /tmp at kernel level
+- PreToolUse hook blocks a fixed list of command patterns: rm against dangerous targets (root, home and its direct children, globs, parent paths, .git, system directories), mkfs, dd writing to a device, sudo, chmod 777, curl piped into bash, eval. Fork bombs are not on that list, there is no pattern for them.
+- The hook carries `"matcher": "Bash"` and greps the command text, so Write and Edit never reach it. It is a typo catcher, not a boundary. See [SECURITY.md](../SECURITY.md).
+- Sandbox profile restricts writes to project directory + /tmp at kernel level. Reads outside the project and outbound network traffic are not restricted.
 - PID lock prevents duplicate runner instances
 - Always recommend sandbox; warn when using skip-permissions without it
 - Cost warning displayed at runner startup — headless runs consume API credits without supervision

--- a/nightshift/SKILL.md
+++ b/nightshift/SKILL.md
@@ -99,7 +99,7 @@ Adapt thresholds to the project. A testing genre needs stricter budgets; a clean
 
 ### Step 4: Validate runbook
 
-Run the 15-point validation (structure, quality, safety, genre-check, autonomy zones, error budget). Show results to the user. Only generate the ZIP once validation passes — or when the user explicitly overrides.
+Run the 15-point validation (structure, quality, safety, genre-check, autonomy zones, error budget). Show results to the user. The build script in step 5 writes the ZIP regardless of the score, so fix a failing check before running it, or ask the user whether to proceed anyway.
 
 The validation catches: missing rollback section, vague steps, steps targeting paths outside the project, hardcoded secrets, `rm -rf` in step text, too many or too few steps, missing autonomy zones, missing error budget.
 
@@ -141,7 +141,7 @@ The ZIP contains:
 | nightshift-run.sh | Main script: headless mode + skip-permissions + PID lock + graceful shutdown |
 | nightshift-run-bg.sh | Background starter (nohup) |
 | nightshift-watchdog.sh | Heartbeat monitor with macOS notification support |
-| nightshift-sandbox.sb | macOS sandbox profile — restricts filesystem to project + /tmp |
+| nightshift-sandbox.sb | macOS sandbox profile: restricts writes to project + /tmp. Reads outside the project and outbound traffic on 443 stay open. |
 | CLAUDE-nightshift.md | Append to CLAUDE.md for project conventions + run memory |
 | README-nightshift.md | Full installation and usage guide |
 

--- a/nightshift/scripts/build_zip.py
+++ b/nightshift/scripts/build_zip.py
@@ -627,7 +627,12 @@ if __name__ == "__main__":
         print(f"\n✅ Validierung: {passed}/{total} — Runbook ist bereit!\n")
 
     # ZIP
-    ZIP_PATH = "/mnt/user-data/outputs/nightshift-setup.zip"
+    # Zielpfad ueberschreibbar, damit der Generator auch ausserhalb der
+    # Claude-Umgebung schreiben kann (Tests, CI, lokale Laeufe).
+    ZIP_PATH = os.environ.get(
+        "NIGHTSHIFT_OUT", "/mnt/user-data/outputs/nightshift-setup.zip"
+    )
+    os.makedirs(os.path.dirname(ZIP_PATH) or ".", exist_ok=True)
 
     files = {
         "runbook.md": RUNBOOK,

--- a/tests/helfer.py
+++ b/tests/helfer.py
@@ -1,0 +1,121 @@
+"""Gemeinsame Hilfen fuer die Tests.
+
+Muss unter Python 3.9 laufen, das ist die dokumentierte Untergrenze.
+Nur Standardbibliothek, keine Abhaengigkeiten.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import zipfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Testwerte fuer die Pflichtvariablen der beiden Generatoren. Der Projektpfad
+# liegt bewusst unter /tmp: die 15-Punkte-Validierung schlaegt bei Pfaden unter
+# /home an und wuerde sonst 14/15 melden.
+GENERATOREN = {
+    "nightshift": {
+        "skript": os.path.join(REPO, "nightshift", "scripts", "build_zip.py"),
+        "zipname": "nightshift-setup.zip",
+        "praefix": "nightshift-setup/",
+        "env": {
+            "NIGHTSHIFT_PROJECT": "/tmp/nightshift-testprojekt",
+            "NIGHTSHIFT_OUT": None,  # wird auf den Zielpfad gesetzt
+        },
+        "ausgabevariable": "NIGHTSHIFT_OUT",
+        "hook_ereignisse": ("PreToolUse", "PostToolUse", "SessionStart", "Stop"),
+    },
+    "24x7": {
+        "skript": os.path.join(REPO, "24x7", "scripts", "build_zip.py"),
+        "zipname": "24x7-setup.zip",
+        "praefix": "24x7-setup/",
+        "env": {
+            "CLAUDE_24X7_WORKSPACE": "/tmp/24x7-testworkspace",
+            "CLAUDE_24X7_OUT": None,
+        },
+        "ausgabevariable": "CLAUDE_24X7_OUT",
+        "hook_ereignisse": ("PreToolUse", "PostToolUse"),
+    },
+}
+
+
+def baue_zip(name, zielordner):
+    """Ruft einen Generator auf und gibt den Pfad der erzeugten ZIP zurueck."""
+    konfig = GENERATOREN[name]
+    ziel = os.path.join(zielordner, konfig["zipname"])
+
+    umgebung = dict(os.environ)
+    for schluessel, wert in konfig["env"].items():
+        umgebung[schluessel] = ziel if wert is None else wert
+
+    lauf = subprocess.run(
+        [sys.executable, konfig["skript"]],
+        env=umgebung,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    ausgabe = lauf.stdout.decode("utf-8", "replace")
+    if lauf.returncode != 0:
+        raise AssertionError(
+            "Generator %s beendet mit Exit-Code %d:\n%s"
+            % (name, lauf.returncode, ausgabe)
+        )
+    if not os.path.isfile(ziel):
+        raise AssertionError(
+            "Generator %s hat keine ZIP unter %s geschrieben:\n%s"
+            % (name, ziel, ausgabe)
+        )
+    return ziel
+
+
+def zip_eintraege(zip_pfad):
+    with zipfile.ZipFile(zip_pfad) as archiv:
+        return sorted(archiv.namelist())
+
+
+def datei_aus_zip(zip_pfad, eintrag):
+    with zipfile.ZipFile(zip_pfad) as archiv:
+        return archiv.read(eintrag).decode("utf-8")
+
+
+def settings_aus_zip(zip_pfad, praefix):
+    return json.loads(datei_aus_zip(zip_pfad, praefix + ".claude/settings.json"))
+
+
+def pretooluse_kommando(settings):
+    """Holt das Hook-Kommando, das Claude vor jedem Bash-Aufruf startet."""
+    eintrag = settings["hooks"]["PreToolUse"][0]
+    if eintrag.get("matcher") != "Bash":
+        raise AssertionError("PreToolUse-Matcher ist nicht 'Bash': %r" % eintrag)
+    return eintrag["hooks"][0]["command"]
+
+
+def block_muster(kommando):
+    """Schneidet das grep-Muster aus dem Hook-Kommando heraus.
+
+    Die beiden Generatoren melden mit unterschiedlichem Text, das Muster selbst
+    muss aber in beiden gleich sein.
+    """
+    teile = kommando.split("'\\''")
+    if len(teile) < 3:
+        raise AssertionError("kein gequotetes grep-Muster im Hook: %r" % kommando)
+    return teile[1]
+
+
+def hook_aufrufen(kommando, bash_kommando):
+    """Schickt ein Bash-Kommando als Hook-Eingabe durch den Hook.
+
+    Rueckgabe: (exit_code, stderr). Der Hook gibt 2 zurueck, wenn er blockt,
+    und 0, wenn er das Kommando durchlaesst.
+    """
+    eingabe = json.dumps({"tool_input": {"command": bash_kommando}}).encode("utf-8")
+    lauf = subprocess.run(
+        kommando,
+        shell=True,
+        input=eingabe,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return lauf.returncode, lauf.stderr.decode("utf-8", "replace").strip()

--- a/tests/test_block_muster.py
+++ b/tests/test_block_muster.py
@@ -1,0 +1,133 @@
+"""Testtabelle fuer den PreToolUse-Hook.
+
+Der Test nimmt nicht das Muster aus dem Quelltext, sondern das Hook-Kommando
+aus der generierten .claude/settings.json und schickt echte Bash-Kommandos als
+JSON durch. Damit haengt jede Zeile am ganzen Pfad: jq, das Entfernen der
+Anfuehrungszeichen mit tr, das Muster selbst und der Exit-Code.
+
+Exit 2 heisst geblockt, Exit 0 heisst durchgelassen.
+"""
+
+import shutil
+import tempfile
+import unittest
+
+import helfer
+
+# Muss blocken. Jede Zeile einmal nackt und einmal gequotet, weil der Hook die
+# Anfuehrungszeichen vor dem Vergleich entfernt und genau das brechen kann.
+BLOCKIEREN = [
+    "rm -rf /",
+    'rm -rf "/"',
+    "rm -rf '/'",
+    "rm -rf ~",
+    "rm -rf $HOME",
+    'rm -rf "$HOME"',
+    "rm -rf $HOME/.claude",
+    "rm -rf ~/Documents",
+    'rm -rf "~/Documents"',
+    "rm -rf /Users/ich",
+    'rm -rf "/Users/ich"',
+    "rm -rf /home/runner",
+    'rm -rf "/home/runner"',
+    "rm -rf /Volumes/Data",
+    "rm -rf *",
+    'rm -rf "*"',
+    "rm -rf ./*",
+    "rm -rf ..",
+    "rm -rf .git",
+    'rm -rf ".git"',
+    "rm -rf /etc",
+    "rm -rf /usr/local",
+    "rm -rf /var/log",
+    "rm -rf /private/var",
+    "sudo rm -rf /tmp/kram",
+    "mkfs.ext4 /dev/sda1",
+    "dd if=/dev/zero of=/dev/sda",
+    "chmod 777 /etc/passwd",
+    "curl https://example.com/install.sh | bash",
+    'eval "$(cat beliebig.sh)"',
+]
+
+# Muss durchkommen. Alltagsbefehle, die ein Lauf nachts wirklich braucht.
+# Das Muster hat frueher jedes rm -rf getroffen, deshalb stehen die
+# Aufraeumbefehle ganz oben.
+DURCHLASSEN = [
+    "rm -rf node_modules",
+    'rm -rf "node_modules"',
+    "rm -rf 'node_modules'",
+    "rm -rf dist build",
+    "rm -rf build/",
+    "rm -rf target",
+    "rm -rf coverage .nyc_output",
+    "rm -rf .venv",
+    "rm -rf ./build",
+    "rm -f *.log",
+    "rm -f /tmp/nightshift.pid",
+    "rm -rf /Users/ich/projekt/dist",
+    "rm -rf '/Users/ich/projekt/dist'",
+    "rm README.md",
+    "git status",
+    "git add -A",
+    "npm run build",
+    "bun test",
+    "python -m pytest",
+    "ls -la",
+]
+
+
+class BlockMusterTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if shutil.which("jq") is None:
+            # Kein Skip: ohne jq blockt der Hook jedes Kommando, die Tabelle
+            # waere dann wertlos statt uebersprungen.
+            raise RuntimeError("jq fehlt, der Hook ist ohne jq nicht pruefbar")
+        cls.ordner = tempfile.mkdtemp(prefix="nightshift-hooktests-")
+        cls.kommandos = {}
+        for name, konfig in helfer.GENERATOREN.items():
+            zip_pfad = helfer.baue_zip(name, cls.ordner)
+            settings = helfer.settings_aus_zip(zip_pfad, konfig["praefix"])
+            cls.kommandos[name] = helfer.pretooluse_kommando(settings)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.ordner, ignore_errors=True)
+
+    def test_gefaehrliche_kommandos_werden_geblockt(self):
+        for name, kommando in self.kommandos.items():
+            for eingabe in BLOCKIEREN:
+                code, fehler = helfer.hook_aufrufen(kommando, eingabe)
+                self.assertEqual(
+                    2,
+                    code,
+                    "%s: %r haette geblockt werden muessen, Exit %d, stderr %r"
+                    % (name, eingabe, code, fehler),
+                )
+                self.assertIn("BLOCKED", fehler, "%s: %r" % (name, eingabe))
+
+    def test_harmlose_kommandos_kommen_durch(self):
+        for name, kommando in self.kommandos.items():
+            for eingabe in DURCHLASSEN:
+                code, fehler = helfer.hook_aufrufen(kommando, eingabe)
+                self.assertEqual(
+                    0,
+                    code,
+                    "%s: %r haette durchkommen muessen, Exit %d, stderr %r"
+                    % (name, eingabe, code, fehler),
+                )
+
+    def test_leeres_kommando_bricht_den_hook_nicht(self):
+        for name, kommando in self.kommandos.items():
+            code, fehler = helfer.hook_aufrufen(kommando, "")
+            self.assertEqual(0, code, "%s: Exit %d, stderr %r" % (name, code, fehler))
+
+    def test_beide_generatoren_nutzen_dasselbe_muster(self):
+        # Das Muster steht doppelt im Repo. Wer nur eine Kopie anfasst, soll das
+        # hier merken und nicht nachts.
+        muster = [helfer.block_muster(k) for k in self.kommandos.values()]
+        self.assertEqual(muster[0], muster[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generatoren.py
+++ b/tests/test_generatoren.py
@@ -1,0 +1,139 @@
+"""Prueft, dass beide Generatoren laufen und ein brauchbares Setup schreiben.
+
+Der Test ruft die Generatoren als eigene Prozesse auf, packt die ZIP in ein
+temporaeres Verzeichnis und schaut hinein.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import helfer
+
+NIGHTSHIFT_DATEIEN = {
+    "nightshift-setup/.claude/settings.json",
+    "nightshift-setup/CLAUDE-nightshift.md",
+    "nightshift-setup/README-nightshift.md",
+    "nightshift-setup/nightshift-run-bg.sh",
+    "nightshift-setup/nightshift-run.sh",
+    "nightshift-setup/nightshift-sandbox.sb",
+    "nightshift-setup/nightshift-watchdog.sh",
+    "nightshift-setup/runbook.md",
+}
+
+VIERUNDZWANZIG_DATEIEN = {
+    "24x7-setup/.claude/settings.json",
+    "24x7-setup/CLAUDE.md",
+    "24x7-setup/README.md",
+    "24x7-setup/failed/.gitkeep",
+    "24x7-setup/idle/idle-tasks.md",
+    "24x7-setup/inbox/.gitkeep",
+    "24x7-setup/inbox/beispiel-task/materials/.gitkeep",
+    "24x7-setup/inbox/beispiel-task/task.md",
+    "24x7-setup/outbox/.gitkeep",
+    "24x7-setup/runner-bg.sh",
+    "24x7-setup/runner.sh",
+    "24x7-setup/sandbox.sb",
+    "24x7-setup/watchdog.sh",
+    "24x7-setup/working/.gitkeep",
+}
+
+
+class GeneratorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ordner = tempfile.mkdtemp(prefix="nightshift-tests-")
+        cls.zips = {
+            name: helfer.baue_zip(name, cls.ordner) for name in helfer.GENERATOREN
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.ordner, ignore_errors=True)
+
+    def test_nightshift_zip_enthaelt_genau_die_erwarteten_dateien(self):
+        self.assertEqual(
+            NIGHTSHIFT_DATEIEN, set(helfer.zip_eintraege(self.zips["nightshift"]))
+        )
+
+    def test_24x7_zip_enthaelt_genau_die_erwarteten_dateien(self):
+        self.assertEqual(
+            VIERUNDZWANZIG_DATEIEN, set(helfer.zip_eintraege(self.zips["24x7"]))
+        )
+
+    def test_settings_json_ist_gueltiges_json_mit_allen_hook_ereignissen(self):
+        for name, zip_pfad in self.zips.items():
+            praefix = helfer.GENERATOREN[name]["praefix"]
+            settings = helfer.settings_aus_zip(zip_pfad, praefix)
+            for ereignis in helfer.GENERATOREN[name]["hook_ereignisse"]:
+                self.assertIn(ereignis, settings["hooks"], "%s: %s" % (name, ereignis))
+            kommando = helfer.pretooluse_kommando(settings)
+            self.assertTrue(kommando.strip(), "%s: leeres Hook-Kommando" % name)
+
+    def test_erzeugte_shellskripte_sind_syntaktisch_gueltig(self):
+        for name, zip_pfad in self.zips.items():
+            skripte = [e for e in helfer.zip_eintraege(zip_pfad) if e.endswith(".sh")]
+            self.assertTrue(skripte, "%s: keine Shellskripte in der ZIP" % name)
+            for eintrag in skripte:
+                inhalt = helfer.datei_aus_zip(zip_pfad, eintrag)
+                self.assertTrue(
+                    inhalt.startswith("#!/bin/bash"),
+                    "%s: kein Shebang" % eintrag,
+                )
+                pfad = os.path.join(self.ordner, os.path.basename(eintrag))
+                with open(pfad, "w") as datei:
+                    datei.write(inhalt)
+                lauf = subprocess.run(
+                    ["bash", "-n", pfad],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                self.assertEqual(
+                    0,
+                    lauf.returncode,
+                    "%s: bash -n meldet %s"
+                    % (eintrag, lauf.stderr.decode("utf-8", "replace")),
+                )
+
+    def test_projektpfad_landet_in_runbook_und_sandboxprofil(self):
+        pfad = helfer.GENERATOREN["nightshift"]["env"]["NIGHTSHIFT_PROJECT"]
+        zip_pfad = self.zips["nightshift"]
+        runbook = helfer.datei_aus_zip(zip_pfad, "nightshift-setup/runbook.md")
+        self.assertIn(pfad, runbook)
+        profil = helfer.datei_aus_zip(
+            zip_pfad, "nightshift-setup/nightshift-sandbox.sb"
+        )
+        self.assertIn('(allow file-read* file-write* (subpath "%s"))' % pfad, profil)
+
+    def test_24x7_readme_kopiert_claude_verzeichnis_in_eigenem_schritt(self):
+        # Das Glob * erfasst keine Dotfiles. Ohne einen eigenen Schritt fuer
+        # .claude laeuft der Daemon ohne Hooks.
+        readme = helfer.datei_aus_zip(self.zips["24x7"], "24x7-setup/README.md")
+        self.assertIn("/.claude/.", readme)
+
+    def test_runbook_validierung_meldet_volle_punktzahl(self):
+        # Der Generator gibt die 15 Checks auf stdout aus. Faellt einer, ist die
+        # Vorlage kaputt, aus der jedes Runbook entsteht.
+        ordner = tempfile.mkdtemp(prefix="nightshift-validierung-")
+        try:
+            konfig = helfer.GENERATOREN["nightshift"]
+            umgebung = dict(os.environ)
+            umgebung["NIGHTSHIFT_PROJECT"] = konfig["env"]["NIGHTSHIFT_PROJECT"]
+            umgebung["NIGHTSHIFT_OUT"] = os.path.join(ordner, "n.zip")
+            lauf = subprocess.run(
+                [sys.executable, konfig["skript"]],
+                env=umgebung,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            ausgabe = lauf.stdout.decode("utf-8", "replace")
+            self.assertIn("15/15", ausgabe, ausgabe)
+        finally:
+            shutil.rmtree(ordner, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Was drin ist

Eine CI, die etwas prueft, das kaputtgehen kann, und vier Richtigstellungen an Aussagen, die der Nachpruefung nicht standhielten.

## Die CI

`.github/workflows/ci.yml`, ausgeloest von push und pull_request auf main sowie von Hand ueber workflow_dispatch. Runner ubuntu-latest, `actions/checkout@v4`, `actions/setup-python@v5` mit `python-version: '3.9'`.

Die Version ist der Punkt. 3.9 ist die dokumentierte Untergrenze und zugleich das System-Python von macOS. Genau dort scheiterte der Nightshift-Generator vor Welle 2 an einem f-String mit Backslash im Ausdruck. Auf 3.12 oder neuer waere dieser Fehler unsichtbar geblieben, und ein gruenes Badge haette den Bruch zugedeckt, der Nutzer trifft.

Drei Schritte:

1. **Kompilieren unter 3.9.** `python -m py_compile` auf beide Generatoren.
2. **Generatoren ausfuehren und ZIP pruefen.** Beide laufen wirklich und schreiben eine ZIP. Verglichen wird die vollstaendige Dateiliste als Menge (8 bzw. 14 Eintraege, ein fehlender wie ein zusaetzlicher faellt auf), dazu: settings.json ist gueltiges JSON mit den erwarteten Hook-Ereignissen, jedes erzeugte Shellskript hat einen Shebang und besteht `bash -n`, der uebergebene Projektpfad landet in runbook.md und als file-write-Regel im Sandboxprofil, die 15-Punkte-Validierung meldet 15/15, und der erzeugte 24x7-README behaelt den eigenen Kopierschritt fuer `.claude`.
3. **Blockmuster des PreToolUse-Hooks.** Der wertvollste Teil. Die Tabelle liest nicht das Muster aus dem Quelltext, sondern zieht das Hook-Kommando aus der generierten `.claude/settings.json` und schickt echte Kommandos als JSON auf stdin hindurch. Damit haengt jede Zeile am ganzen Pfad: jq, das Entfernen der Anfuehrungszeichen mit `tr`, das Muster, der Exit-Code. 30 gefaehrliche Kommandos muessen mit Exit 2 blocken, 20 harmliche mit Exit 0 durchkommen, die Pfadfaelle jeweils nackt und gequotet. Jede Zeile laeuft gegen beide Generatoren, macht 100 echte Hook-Aufrufe pro Lauf. Dazu ein Test, dass beide Generatoren dasselbe Muster tragen: es steht doppelt im Repo, und wer nur eine Kopie anfasst, soll es hier merken und nicht nachts.

Die harmlose Haelfte ist der Regressionsschutz fuer Welle 2: `rm -rf node_modules` und `rm -rf dist` wurden vorher geblockt, ein Lauf blieb an einem legitimen Aufraeumschritt haengen.

## Was die CI nicht prueft

- Kein Runner, kein Watchdog wird ausgefuehrt. `claude` steht in der CI nicht zur Verfuegung, die Shellskripte werden nur auf Syntax geprueft.
- Das Seatbelt-Profil wird nicht validiert. `sandbox-exec` gibt es nur auf macOS, und Apple hat es als veraltet markiert.
- Die dokumentierten Installationsbefehle werden nicht nachgespielt.
- Kein macOS-Runner. Der geprueft Inhalt braucht keinen, aber damit bleibt das Verhalten des Hooks unter BSD-grep in der CI ungeprueft.
- Nichts prueft die Kosten, das Verhalten bei fehlendem `timeout` oder das Zusammenspiel mit einer bestehenden settings.json.

## Belegt

Beide Zaehne-Tests auf einer Kopie ausserhalb des Repos:

**Muster gebrochen** (`sudo ` aus BLOCK_PATTERN entfernt): Schritt 3 wird rot, zwei Fehlschlaege, Exit-Code 1. `AssertionError: 2 != 0 : nightshift: 'sudo rm -rf /tmp/kram' haette geblockt werden muessen, Exit 0` und zusaetzlich der Vergleich der beiden Generatoren.

**f-String gebrochen** (Zustand vor Welle 2 wiederhergestellt): Schritt 1 meldet unter /usr/bin/python3 3.9.6 `SyntaxError: f-string expression part cannot include a backslash`, Exit 1. Dieselbe Datei mit Python 3.13: Exit 0. Das ist der Grund fuer die feste 3.9 im Workflow.

## Richtiggestellte Aussagen

- **Seatbelt-Profil als "the real security boundary"** (README Z. 52 und 425, index.html Z. 1064 und 1207). Es ist eine Schreibgrenze. Das Profil erlaubt `file-read*` auf `$HOME/.claude` und `$HOME/.config` und `(allow network-outbound (remote tcp "*:443"))` ohne Zielangabe. Was der Lauf lesen kann, kann er auch verschicken. Neuer README-Abschnitt "What the Sandbox Does Not Cover", Threat Model nicht gedoppelt, sondern auf SECURITY.md verlinkt.
- **Fork-Bomben im Hook** (nightshift/SKILL.md Z. 171, 24x7/SKILL.md Z. 142, index.html Z. 1016). Im Muster steht dazu nichts. Die Liste nennt jetzt, was tatsaechlich blockt, dazu der Hinweis, dass der Hook nur Bash sieht.
- **Linux-Rezept** (README, beide Nightshift-Anleitungen, index.html Z. 1222). Die Kopie aus `sudo cp -r` gehoert root, und im erzeugten `nightshift-run.sh` steht ein fester `cd` auf den Pfad aus dem Generierungslauf. Docker steht jetzt vorn, das Benutzerkonto ist als schwaechere Variante gekennzeichnet und um `chown`, das Neuerzeugen mit passendem `NIGHTSHIFT_PROJECT` und die fehlende Anmeldung ergaenzt.
- **Roadmap** ergaenzt, ohne Termine, mit den offenen Punkten in der Reihenfolge, in der sie Nutzer treffen.

Mitgenommen, weil dieselbe Aussage: der Absatz "Workspace Isolation" im englischen 24x7-Leitfaden, der Zugriff auf Heimatverzeichnis und Internet ausgeschlossen hatte.

## Verhaeltnis zu PR #1 (SECURITY.md)

SECURITY.md ist hier nicht angefasst. Die Korrekturen verlinken sie: relativ aus README und SKILL.md, absolut aus index.html, weil GitHub Pages keine .md ausliefert. Alle drei Links loesen erst auf, wenn #1 gemergt ist.

SECURITY.md beschreibt den Stand von main. Die Welle-2-Commits unter diesem Branch erledigen bereits ihre Known Gaps 1, 2, 4, 5 und 6. Nach dem Merge beider PRs sind dort mindestens Gap 2 ("das Muster trifft jedes rm -rf") und Gap 3 (Fork-Bomben-Behauptung in SKILL.md) veraltet. Das gehoert in einen eigenen Nachlauf, nicht in diesen PR.

## Eine Codeaenderung ausserhalb von CI und Tests

Beide Generatoren schrieben fest nach `/mnt/user-data/outputs`. Diesen Pfad gibt es nur in der Claude-Umgebung, auf macOS laesst er sich nicht einmal anlegen, und ohne beschreibbares Ziel kann keine CI den Generator ausfuehren. `NIGHTSHIFT_OUT` und `CLAUDE_24X7_OUT` ueberschreiben ihn jetzt, die Vorgabe bleibt unveraendert, das Zielverzeichnis wird angelegt. Dazu eine `.gitignore` mit `__pycache__/` und `*.pyc`, damit der Kompilierschritt keine Artefakte hinterlaesst.

## Offen

- Die Schritte wurden lokal mit `/usr/bin/python3` (3.9.6) unter macOS ausgefuehrt, also mit BSD-grep, bash 3.2 und macOS-sh. Der Runner bringt GNU-grep, bash 5 und dash mit. Das Muster ist reines POSIX-ERE, das Risiko also gering, geprueft ist es dort aber erst nach dem ersten Lauf.
- Python 3.9 ist seit Oktober 2025 am Ende der Unterstuetzung. Ob `setup-python@v5` fuer das aktuelle `ubuntu-latest` noch einen 3.9-Build liefert, laesst sich von hier nicht feststellen. Sollte der erste Lauf daran scheitern, liegt es an diesem Punkt und nicht an den Tests.
- Der Hook braucht jq. Fehlt jq, bricht der Testlauf mit klarer Meldung ab, statt zu ueberspringen: ohne jq blockt der Hook jedes Kommando, die Tabelle waere dann wertlos.
- Der Installationsweg ueber Release-Assets liefert weiterhin 404. Steht als erster Punkt in der Roadmap.

## Wie dieser Branch entstanden ist

Drei Durchgaenge, jeder mit eigener Abnahme:

1. CI anlegen und die im Haerteplan gelisteten Falschaussagen korrigieren.
2. Die Abnahme hat die CI selbst nachgefahren, absichtlich gebrochen, um zu pruefen ob sie Zaehne
   hat, und dabei 9 weitere Aussagen gefunden, die immer noch nicht stimmten. Die wurden im
   zweiten Durchgang korrigiert.
3. Die Nachpruefung des zweiten Durchgangs fand Formulierungen, die beim Korrigieren zu weit
   gingen oder eine neue Ungenauigkeit einfuehrten. Die wurden im dritten Durchgang praezisiert.

Jede Zahl in den geaenderten Texten ist gegen das Repo gemessen, nicht uebernommen.

## Zur CI

Die CI prueft nur, was heute wirklich pruefbar ist. Sie wurde absichtlich gebrochen, um zu
belegen, dass ein realistischer Fehler sie rot macht. Was sie nicht abdeckt, steht in der
Beschreibung der einzelnen Schritte.


---
**Gestapelt.** Dieser PR sitzt auf `fix/welle-2`. GitHub haengt ihn automatisch auf `main` um, sobald der darunterliegende PR gemergt ist. Vorher zeigt der Diff nur die Welle-3-Aenderungen, das ist so gewollt.

Teil von Welle 3 des Haerteplans: CI sichtbar und Claims ehrlich. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die CI-Schritte selbst nachgefahren und die CI absichtlich gebrochen hat.
